### PR TITLE
[DPE-7512] Multinode deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing
+# Contributing workflow
 
 To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
 
-You can create an environment for development with `tox`:
+You can, but not required to, create an environment for development with `tox`:
 
 ```shell
 tox devenv -e integration
@@ -12,15 +12,16 @@ source venv/bin/activate
 ## Testing
 
 This project uses `tox` for managing test environments. There are some pre-configured environments
-that can be used for linting and formatting code when you're preparing contributions to the charm:
+that can be used for linting, formatting and testing code when you're preparing contributions to the charm:
 
 ```shell
-tox run -e format        # update your code according to linting rules
-tox run -e lint          # code style
-tox run -e static        # static type checking
-tox run -e unit          # unit tests
-tox run -e integration   # integration tests
-tox                      # runs 'format', 'lint', 'static', and 'unit' environments
+tox run -e format                 # update your code according to linting rules
+tox run -e lint                   # verify your code according to linting rules
+tox run -e unit                   # run unit tests
+tox run -e integration-charm      # run charm integration test
+tox run -e integration-config     # run config integration test
+tox run -e integration-multinode  # run multinode integration test
+tox run -e integration-scaling    # run scaling integration test
 ```
 
 ## Build the charm

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,6 +20,8 @@ charm-libs:
     version: "1"
   - lib: data_platform_libs.data_interfaces
     version: "0"
+  - lib: rolling_ops.rollingops
+    version: "0"
 
 config:
   options:
@@ -35,6 +37,8 @@ config:
 peers:
   cassandra-peers:
     interface: cassandra_peers
+  bootstrap:
+    interface: rolling_op
 
 parts:
   # "poetry-deps" part name is a magic constant

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 46
+LIBPATCH = 48
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -2569,7 +2569,7 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
 
 
 ################################################################################
-# Cross-charm Relatoins Data Handling and Evenets
+# Cross-charm Relations Data Handling and Events
 ################################################################################
 
 # Generic events
@@ -3268,7 +3268,7 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
 # Kafka Events
 
 
-class KafkaProvidesEvent(RelationEvent):
+class KafkaProvidesEvent(RelationEventWithSecret):
     """Base class for Kafka events."""
 
     @property
@@ -3287,6 +3287,40 @@ class KafkaProvidesEvent(RelationEvent):
 
         return self.relation.data[self.relation.app].get("consumer-group-prefix")
 
+    @property
+    def mtls_cert(self) -> Optional[str]:
+        """Returns TLS cert of the client."""
+        if not self.relation.app:
+            return None
+
+        if not self.secrets_enabled:
+            raise SecretsUnavailableError("Secrets unavailable on current Juju version")
+
+        secret_field = f"{PROV_SECRET_PREFIX}{SECRET_GROUPS.MTLS}"
+        if secret_uri := self.relation.data[self.app].get(secret_field):
+            secret = self.framework.model.get_secret(id=secret_uri)
+            content = secret.get_content(refresh=True)
+            if content:
+                return content.get("mtls-cert")
+
+
+class KafkaClientMtlsCertUpdatedEvent(KafkaProvidesEvent):
+    """Event emitted when the mtls relation is updated."""
+
+    def __init__(self, handle, relation, old_mtls_cert: Optional[str] = None, app=None, unit=None):
+        super().__init__(handle, relation, app, unit)
+
+        self.old_mtls_cert = old_mtls_cert
+
+    def snapshot(self):
+        """Return a snapshot of the event."""
+        return super().snapshot() | {"old_mtls_cert": self.old_mtls_cert}
+
+    def restore(self, snapshot):
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        self.old_mtls_cert = snapshot["old_mtls_cert"]
+
 
 class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new topic is requested for use on this relation."""
@@ -3299,6 +3333,7 @@ class KafkaProvidesEvents(CharmEvents):
     """
 
     topic_requested = EventSource(TopicRequestedEvent)
+    mtls_cert_updated = EventSource(KafkaClientMtlsCertUpdatedEvent)
 
 
 class KafkaRequiresEvent(RelationEvent):
@@ -3416,6 +3451,13 @@ class KafkaProviderEventHandlers(ProviderEventHandlers):
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
         super()._on_relation_changed_event(event)
+
+        new_data_keys = list(event.relation.data[event.app].keys())
+        if any(newval for newval in new_data_keys if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, new_data_keys)
+
+        getattr(self.on, "mtls_cert_updated").emit(event.relation, app=event.app, unit=event.unit)
+
         # Leader only
         if not self.relation_data.local_unit.is_leader():
             return
@@ -3429,6 +3471,33 @@ class KafkaProviderEventHandlers(ProviderEventHandlers):
             getattr(self.on, "topic_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        if not event.secret.label:
+            return
+
+        relation = self.relation_data._relation_from_secret_label(event.secret.label)
+        if not relation:
+            logging.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant"
+            )
+            return
+
+        if relation.app == self.charm.app:
+            logging.info("Secret changed event ignored for Secret Owner")
+
+        remote_unit = None
+        for unit in relation.units:
+            if unit.app != self.charm.app:
+                remote_unit = unit
+
+        old_mtls_cert = event.secret.get_content().get("mtls-cert")
+        # mtls-cert is the only secret that can be updated
+        logger.info("mtls-cert updated")
+        getattr(self.on, "mtls_cert_updated").emit(
+            relation, app=relation.app, unit=remote_unit, old_mtls_cert=old_mtls_cert
+        )
 
 
 class KafkaProvides(KafkaProviderData, KafkaProviderEventHandlers):
@@ -3450,11 +3519,13 @@ class KafkaRequirerData(RequirerData):
         extra_user_roles: Optional[str] = None,
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        mtls_cert: Optional[str] = None,
     ):
         """Manager of Kafka client relations."""
         super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
         self.topic = topic
         self.consumer_group_prefix = consumer_group_prefix or ""
+        self.mtls_cert = mtls_cert
 
     @property
     def topic(self):
@@ -3467,6 +3538,15 @@ class KafkaRequirerData(RequirerData):
         if value == "*":
             raise ValueError(f"Error on topic '{value}', cannot be a wildcard.")
         self._topic = value
+
+    def set_mtls_cert(self, relation_id: int, mtls_cert: str) -> None:
+        """Set the mtls cert in the application relation databag / secret.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            mtls_cert: mtls cert.
+        """
+        self.update_relation_data(relation_id, {"mtls-cert": mtls_cert})
 
 
 class KafkaRequirerEventHandlers(RequirerEventHandlers):
@@ -3488,6 +3568,9 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
 
         # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
         relation_data = {"topic": self.relation_data.topic}
+
+        if self.relation_data.mtls_cert:
+            relation_data["mtls-cert"] = self.relation_data.mtls_cert
 
         if self.relation_data.extra_user_roles:
             relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
@@ -3547,15 +3630,17 @@ class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
         extra_user_roles: Optional[str] = None,
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
+        mtls_cert: Optional[str] = None,
     ) -> None:
         KafkaRequirerData.__init__(
             self,
             charm.model,
             relation_name,
             topic,
-            extra_user_roles,
-            consumer_group_prefix,
-            additional_secret_fields,
+            extra_user_roles=extra_user_roles,
+            consumer_group_prefix=consumer_group_prefix,
+            additional_secret_fields=additional_secret_fields,
+            mtls_cert=mtls_cert,
         )
         KafkaRequirerEventHandlers.__init__(self, charm, self)
 
@@ -3674,6 +3759,10 @@ class OpenSearchProvidesEventHandlers(ProviderEventHandlers):
             getattr(self.on, "index_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        pass
 
 
 class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers):

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -1,0 +1,425 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This library enables "rolling" operations across units of a charmed Application.
+
+For example, a charm author might use this library to implement a "rolling restart", in
+which all units in an application restart their workload, but no two units execute the
+restart at the same time.
+
+To implement the rolling restart, a charm author would do the following:
+
+1. Add a peer relation called 'restart' to a charm's `metadata.yaml`:
+```yaml
+peers:
+    restart:
+        interface: rolling_op
+```
+
+Import this library into src/charm.py, and initialize a RollingOpsManager in the Charm's
+`__init__`. The Charm should also define a callback routine, which will be executed when
+a unit holds the distributed lock:
+
+src/charm.py
+```python
+# ...
+from charms.rolling_ops.v0.rollingops import RollingOpsManager
+# ...
+class SomeCharm(...):
+    def __init__(...)
+        # ...
+        self.restart_manager = RollingOpsManager(
+            charm=self, relation="restart", callback=self._restart
+        )
+        # ...
+    def _restart(self, event):
+        systemd.service_restart('foo')
+```
+
+To kick off the rolling restart, emit this library's AcquireLock event. The simplest way
+to do so would be with an action, though it might make sense to acquire the lock in
+response to another event.
+
+```python
+    def _on_trigger_restart(self, event):
+        self.charm.on[self.restart_manager.name].acquire_lock.emit()
+```
+
+In order to trigger the restart, a human operator would execute the following command on
+the CLI:
+
+```
+juju run-action some-charm/0 some-charm/1 <... some-charm/n> restart
+```
+
+Note that all units that plan to restart must receive the action and emit the acquire
+event. Any units that do not run their acquire handler will be left out of the rolling
+restart. (An operator might take advantage of this fact to recover from a failed rolling
+operation without restarting workloads that were able to successfully restart -- simply
+omit the successful units from a subsequent run-action call.)
+
+"""
+
+import logging
+from enum import Enum
+from typing import AnyStr, Callable, Optional
+
+from ops.charm import ActionEvent, CharmBase, RelationChangedEvent
+from ops.framework import EventBase, Object
+from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "20b7777f58fe421e9a223aefc2b4d3a4"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 8
+
+
+class LockNoRelationError(Exception):
+    """Raised if we are trying to process a lock, but do not appear to have a relation yet."""
+
+    pass
+
+
+class LockState(Enum):
+    """Possible states for our Distributed lock.
+
+    Note that there are two states set on the unit, and two on the application.
+
+    """
+
+    ACQUIRE = "acquire"
+    RELEASE = "release"
+    GRANTED = "granted"
+    IDLE = "idle"
+
+
+class Lock:
+    """A class that keeps track of a single asynchronous lock.
+
+    Warning: a Lock has permission to update relation data, which means that there are
+    side effects to invoking the .acquire, .release and .grant methods. Running any one of
+    them will trigger a RelationChanged event, once per transition from one internal
+    status to another.
+
+    This class tracks state across the cloud by implementing a peer relation
+    interface. There are two parts to the interface:
+
+    1) The data on a unit's peer relation (defined in metadata.yaml.) Each unit can update
+       this data. The only meaningful values are "acquire", and "release", which represent
+       a request to acquire the lock, and a request to release the lock, respectively.
+
+    2) The application data in the relation. This tracks whether the lock has been
+       "granted", Or has been released (and reverted to idle). There are two valid states:
+       "granted" or None.  If a lock is in the "granted" state, a unit should emit a
+       RunWithLocks event and then release the lock.
+
+       If a lock is in "None", this means that a unit has not yet requested the lock, or
+       that the request has been completed.
+
+    In more detail, here is the relation structure:
+
+    relation.data:
+        <unit n>:
+            status: 'acquire|release'
+        <application>:
+           <unit n>: 'granted|None'
+
+    Note that this class makes no attempts to timestamp the locks and thus handle multiple
+    requests in a row. If a unit re-requests a lock before being granted the lock, the
+    lock will simply stay in the "acquire" state. If a unit wishes to clear its lock, it
+    simply needs to call lock.release().
+
+    """
+
+    def __init__(self, manager, unit=None):
+        self.relation = manager.model.relations[manager.name][0]
+        if not self.relation:
+            # TODO: defer caller in this case (probably just fired too soon).
+            raise LockNoRelationError()
+
+        self.unit = unit or manager.model.unit
+        self.app = manager.model.app
+
+    @property
+    def _state(self) -> LockState:
+        """Return an appropriate state.
+
+        Note that the state exists in the unit's relation data, and the application
+        relation data, so we have to be careful about what our states mean.
+
+        Unit state can only be in "acquire", "release", "None" (None means unset)
+        Application state can only be in "granted" or "None" (None means unset or released)
+
+        """
+        unit_state = LockState(self.relation.data[self.unit].get("state", LockState.IDLE.value))
+        app_state = LockState(
+            self.relation.data[self.app].get(str(self.unit), LockState.IDLE.value)
+        )
+
+        if app_state == LockState.GRANTED and unit_state == LockState.RELEASE:
+            # Active release request.
+            return LockState.RELEASE
+
+        if app_state == LockState.IDLE and unit_state == LockState.ACQUIRE:
+            # Active acquire request.
+            return LockState.ACQUIRE
+
+        logger.debug("Lock state: %s %s", unit_state, app_state)
+        return app_state  # Granted or unset/released
+
+    @_state.setter
+    def _state(self, state: LockState):
+        """Set the given state.
+
+        Since we update the relation data, this may fire off a RelationChanged event.
+        """
+        if state == LockState.ACQUIRE:
+            self.relation.data[self.unit].update({"state": state.value})
+
+        if state == LockState.RELEASE:
+            self.relation.data[self.unit].update({"state": state.value})
+
+        if state == LockState.GRANTED:
+            self.relation.data[self.app].update({str(self.unit): state.value})
+
+        if state is LockState.IDLE:
+            self.relation.data[self.app].update({str(self.unit): state.value})
+
+        logger.debug("state: %s", state.value)
+
+    def acquire(self):
+        """Request that a lock be acquired."""
+        self._state = LockState.ACQUIRE
+        logger.debug("Lock acquired.")
+
+    def release(self):
+        """Request that a lock be released."""
+        self._state = LockState.RELEASE
+        logger.debug("Lock released.")
+
+    def clear(self):
+        """Unset a lock."""
+        self._state = LockState.IDLE
+        logger.debug("Lock cleared.")
+
+    def grant(self):
+        """Grant a lock to a unit."""
+        self._state = LockState.GRANTED
+        logger.debug("Lock granted.")
+
+    def is_held(self):
+        """This unit holds the lock."""
+        return self._state == LockState.GRANTED
+
+    def release_requested(self):
+        """A unit has reported that they are finished with the lock."""
+        return self._state == LockState.RELEASE
+
+    def is_pending(self):
+        """Is this unit waiting for a lock?"""
+        return self._state == LockState.ACQUIRE
+
+
+class Locks:
+    """Generator that returns a list of locks."""
+
+    def __init__(self, manager):
+        self.manager = manager
+
+        # Gather all the units.
+        relation = manager.model.relations[manager.name][0]
+        units = list(relation.units)
+
+        # Plus our unit ...
+        units.append(manager.model.unit)
+
+        self.units = units
+
+    def __iter__(self):
+        """Yields a lock for each unit we can find on the relation."""
+        for unit in self.units:
+            yield Lock(self.manager, unit=unit)
+
+
+class RunWithLock(EventBase):
+    """Event to signal that this unit should run the callback."""
+
+    pass
+
+
+class AcquireLock(EventBase):
+    """Signals that this unit wants to acquire a lock."""
+
+    def __init__(self, handle, callback_override: Optional[str] = None):
+        super().__init__(handle)
+        self.callback_override = callback_override or ""
+
+    def snapshot(self):
+        """Snapshot of lock event."""
+        return {"callback_override": self.callback_override}
+
+    def restore(self, snapshot):
+        """Restores lock event."""
+        self.callback_override = snapshot["callback_override"]
+
+
+class ProcessLocks(EventBase):
+    """Used to tell the leader to process all locks."""
+
+    pass
+
+
+class RollingOpsManager(Object):
+    """Emitters and handlers for rolling ops."""
+
+    def __init__(self, charm: CharmBase, relation: AnyStr, callback: Callable):
+        """Register our custom events.
+
+        params:
+            charm: the charm we are attaching this to.
+            relation: an identifier, by convention based on the name of the relation in the
+                metadata.yaml, which identifies this instance of RollingOperatorsFactory,
+                distinct from other instances that may be handling other events.
+            callback: a closure to run when we have a lock. (It must take a CharmBase object and
+                EventBase object as args.)
+        """
+        # "Inherit" from the charm's class. This gives us access to the framework as
+        # self.framework, as well as the self.model shortcut.
+        super().__init__(charm, None)
+
+        self.name = relation
+        self._callback = callback
+        self.charm = charm  # Maintain a reference to charm, so we can emit events.
+
+        charm.on.define_event("{}_run_with_lock".format(self.name), RunWithLock)
+        charm.on.define_event("{}_acquire_lock".format(self.name), AcquireLock)
+        charm.on.define_event("{}_process_locks".format(self.name), ProcessLocks)
+
+        # Watch those events (plus the built in relation event).
+        self.framework.observe(charm.on[self.name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[self.name].acquire_lock, self._on_acquire_lock)
+        self.framework.observe(charm.on[self.name].run_with_lock, self._on_run_with_lock)
+        self.framework.observe(charm.on[self.name].process_locks, self._on_process_locks)
+        self.framework.observe(charm.on.leader_elected, self._on_process_locks)
+
+    def _callback(self: CharmBase, event: EventBase) -> None:
+        """Placeholder for the function that actually runs our event.
+
+        Usually overridden in the init.
+        """
+        raise NotImplementedError
+
+    def _on_relation_changed(self: CharmBase, event: RelationChangedEvent):
+        """Process relation changed.
+
+        First, determine whether this unit has been granted a lock. If so, emit a RunWithLock
+        event.
+
+        Then, if we are the leader, fire off a process locks event.
+
+        """
+        lock = Lock(self)
+
+        if lock.is_pending():
+            self.model.unit.status = WaitingStatus("Awaiting {} operation".format(self.name))
+
+        if lock.is_held():
+            self.charm.on[self.name].run_with_lock.emit()
+
+        if self.model.unit.is_leader():
+            self.charm.on[self.name].process_locks.emit()
+
+    def _on_process_locks(self: CharmBase, event: ProcessLocks):
+        """Process locks.
+
+        Runs only on the leader. Updates the status of all locks.
+
+        """
+        if not self.model.unit.is_leader():
+            return
+
+        pending = []
+
+        for lock in Locks(self):
+            if lock.is_held():
+                # One of our units has the lock -- return without further processing.
+                return
+
+            if lock.release_requested():
+                lock.clear()  # Updates relation data
+
+            if lock.is_pending():
+                if lock.unit == self.model.unit:
+                    # Always run on the leader last.
+                    pending.insert(0, lock)
+                else:
+                    pending.append(lock)
+
+        # If we reach this point, and we have pending units, we want to grant a lock to
+        # one of them.
+        if pending:
+            self.model.app.status = MaintenanceStatus("Beginning rolling {}".format(self.name))
+            lock = pending[-1]
+            lock.grant()
+            if lock.unit == self.model.unit:
+                # It's time for the leader to run with lock.
+                self.charm.on[self.name].run_with_lock.emit()
+            return
+
+        if self.model.app.status.message == f"Beginning rolling {self.name}":
+            self.model.app.status = ActiveStatus()
+
+    def _on_acquire_lock(self: CharmBase, event: ActionEvent):
+        """Request a lock."""
+        try:
+            Lock(self).acquire()  # Updates relation data
+            # emit relation changed event in the edge case where acquire does not
+            relation = self.model.get_relation(self.name)
+
+            # persist callback override for eventual run
+            relation.data[self.charm.unit].update({"callback_override": event.callback_override})
+            self.charm.on[self.name].relation_changed.emit(relation, app=self.charm.app)
+
+        except LockNoRelationError:
+            logger.debug("No {} peer relation yet. Delaying rolling op.".format(self.name))
+            event.defer()
+
+    def _on_run_with_lock(self: CharmBase, event: RunWithLock):
+        lock = Lock(self)
+        self.model.unit.status = MaintenanceStatus("Executing {} operation".format(self.name))
+        relation = self.model.get_relation(self.name)
+
+        # default to instance callback if not set
+        callback_name = relation.data[self.charm.unit].get(
+            "callback_override", self._callback.__name__
+        )
+        callback = getattr(self.charm, callback_name)
+        callback(event)
+
+        lock.release()  # Updates relation data
+        if lock.unit == self.model.unit:
+            self.charm.on[self.name].process_locks.emit()
+
+        # cleanup old callback overrides
+        relation.data[self.charm.unit].update({"callback_override": ""})
+
+        if self.model.unit.status.message == f"Executing {self.name} operation":
+            self.model.unit.status = ActiveStatus()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1321,14 +1321,14 @@ pytz = "*"
 
 [[package]]
 name = "pyright"
-version = "1.1.402"
+version = "1.1.403"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 groups = ["lint"]
 files = [
-    {file = "pyright-1.1.402-py3-none-any.whl", hash = "sha256:2c721f11869baac1884e846232800fe021c33f1b4acb3929cff321f7ea4e2982"},
-    {file = "pyright-1.1.402.tar.gz", hash = "sha256:85a33c2d40cd4439c66aa946fd4ce71ab2f3f5b8c22ce36a623f59ac22937683"},
+    {file = "pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3"},
+    {file = "pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104"},
 ]
 
 [package.dependencies]
@@ -1923,4 +1923,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "03f6e10b7c3d2c61179d7db37f2e5da151cff05067ec56c722b3874e8f0efc9e"
+content-hash = "9cea58acf0c8c9aed155b1a3c0cccf4b3b35495750d89df05f4a10b14f7133c1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -233,7 +233,7 @@ version = "3.29.2"
 description = "DataStax Driver for Apache Cassandra"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["main", "integration"]
 files = [
     {file = "cassandra-driver-3.29.2.tar.gz", hash = "sha256:c4310a7d0457f51a63fb019d8ef501588c491141362b53097fbc62fa06559b7c"},
     {file = "cassandra_driver-3.29.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:957208093ff2353230d0d83edf8c8e8582e4f2999d9a33292be6558fec943562"},
@@ -490,7 +490,7 @@ version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integration"]
 files = [
     {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
     {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
@@ -528,7 +528,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", integration = "sys_platform == \"win32\"", unit = "sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\"", integration = "platform_system == \"Windows\" or sys_platform == \"win32\"", unit = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -709,7 +709,7 @@ version = "0.2.1.post1"
 description = "GeoJSON <-> WKT/WKB conversion utilities"
 optional = false
 python-versions = ">2.6, !=3.3.*, <4"
-groups = ["main"]
+groups = ["main", "integration"]
 files = [
     {file = "geomet-0.2.1.post1-py3-none-any.whl", hash = "sha256:a41a1e336b381416d6cbed7f1745c848e91defaa4d4c1bdc1312732e46ffad2b"},
     {file = "geomet-0.2.1.post1.tar.gz", hash = "sha256:91d754f7c298cbfcabd3befdb69c641c27fe75e808b27aa55028605761d17e95"},
@@ -1924,4 +1924,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "3cfe94147fdf7547f612e4aeb156b4ca33effdc140b061c2dec9ceda1d2e3d2b"
+content-hash = "67dce2b6277a418edb594fdc423581b619fad458d0f8582b3de7b2980df74728"

--- a/poetry.lock
+++ b/poetry.lock
@@ -967,42 +967,41 @@ importlib-metadata = ">=6.0,<8.7.0"
 
 [[package]]
 name = "ops"
-version = "2.22.0"
+version = "2.23.0"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "unit"]
 files = [
-    {file = "ops-2.22.0-py3-none-any.whl", hash = "sha256:ad44326bc065e33357b47e1cf4c73e811b2fdb3c89dd0c9bdf421a7a028bdcf7"},
-    {file = "ops-2.22.0.tar.gz", hash = "sha256:bd1cd1229e83efb8ae2d97d8878c7db3deceb6819eb5a38fb6e235a959528ec2"},
+    {file = "ops-2.23.0-py3-none-any.whl", hash = "sha256:7a42840410e8570acc3a4b498973a5bcd3fd0b12dd06837f57b9379b3acdfac3"},
+    {file = "ops-2.23.0.tar.gz", hash = "sha256:3e6c29a8f2119c7b8eaa88c82b5371de236dfcb7a7bf0012a6e2a829f0837fb7"},
 ]
 
 [package.dependencies]
 importlib-metadata = "*"
 opentelemetry-api = ">=1.0,<2.0"
-ops-scenario = {version = "7.22.0", optional = true, markers = "extra == \"testing\""}
+ops-scenario = {version = "7.23.0", optional = true, markers = "extra == \"testing\""}
 PyYAML = "==6.*"
 websocket-client = "==1.*"
 
 [package.extras]
-docs = ["canonical-sphinx-extensions", "furo", "linkify-it-py", "myst-parser", "pyspelling", "sphinx (>=8.0.0,<8.1.0)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "sphinx-notfound-page", "sphinx-tabs", "sphinxcontrib-jquery", "sphinxext-opengraph"]
-testing = ["ops-scenario (==7.22.0)"]
-tracing = ["ops-tracing (==2.22.0)"]
+testing = ["ops-scenario (==7.23.0)"]
+tracing = ["ops-tracing (==2.23.0)"]
 
 [[package]]
 name = "ops-scenario"
-version = "7.22.0"
+version = "7.23.0"
 description = "Python library providing a state-transition testing API for Operator Framework charms."
 optional = false
 python-versions = ">=3.8"
 groups = ["unit"]
 files = [
-    {file = "ops_scenario-7.22.0-py3-none-any.whl", hash = "sha256:a42d3acf831fc46f213286268e31d14c2ffc5ea72452c49955de76895f62437c"},
-    {file = "ops_scenario-7.22.0.tar.gz", hash = "sha256:15921e6849773b81df90ad4d78f573e0af5f5b9ddbfc82603c991c29648d8070"},
+    {file = "ops_scenario-7.23.0-py3-none-any.whl", hash = "sha256:88ddb6b8b41688c580b38fc10dfa3706ab65a481931c26b07a298f2dd82a86ae"},
+    {file = "ops_scenario-7.23.0.tar.gz", hash = "sha256:32a40966a92138779e5f47fff0653037e98e4561fcb30a02014733a88a68c998"},
 ]
 
 [package.dependencies]
-ops = "2.22.0"
+ops = "2.23.0"
 PyYAML = ">=6.0.1"
 
 [[package]]
@@ -1924,4 +1923,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "67dce2b6277a418edb594fdc423581b619fad458d0f8582b3de7b2980df74728"
+content-hash = "03f6e10b7c3d2c61179d7db37f2e5da151cff05067ec56c722b3874e8f0efc9e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ optional = true
 
 [tool.poetry.group.lint.dependencies]
 codespell = "^2.4.1"
-pyright = "^1.1.402"
+pyright = "^1.1.403"
 
 [tool.poetry.group.unit]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ coverage = {extras = ["toml"], version = "^7.8.0"}
 pytest = "^8.4.1"
 pytest-mock = "^3.14.1"
 ops = {version = "^2.22.0", extras = ["testing"]}
+ops-scenario = "^7.23.0"
 
 [tool.poetry.group.integration]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ juju = "<=3.6.1.1"
 tenacity = "*"
 allure-pytest = "^2.14.0"
 allure-pytest-default-results = "^0.1.2"
+cassandra-driver = "^3.29.2"
 
 # Testing tools configuration
 [tool.coverage.run]

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,11 +7,10 @@
 import logging
 
 from charms.data_platform_libs.v1.data_models import TypedCharmBase
-from ops import CollectStatusEvent, main
+from ops import main
 
 from core.config import CharmConfig
 from core.state import ApplicationState
-from core.statuses import Status
 from events.cassandra import CassandraEvents
 from managers.cluster import ClusterManager
 from managers.config import ConfigManager
@@ -33,9 +32,6 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
         cluster_manager = ClusterManager(workload=workload)
         config_manager = ConfigManager(workload=workload)
 
-        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
-        self.framework.observe(self.on.collect_app_status, self._on_collect_app_status)
-
         self.cassandra_events = CassandraEvents(
             self,
             state=state,
@@ -43,12 +39,6 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
             cluster_manager=cluster_manager,
             config_manager=config_manager,
         )
-
-    def _on_collect_unit_status(self, event: CollectStatusEvent) -> None:
-        event.add_status(Status.ACTIVE.value)
-
-    def _on_collect_app_status(self, event: CollectStatusEvent) -> None:
-        event.add_status(Status.ACTIVE.value)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,9 +9,10 @@ import logging
 from charms.data_platform_libs.v1.data_models import TypedCharmBase
 from charms.rolling_ops.v0.rollingops import RollingOpsManager, RunWithLock
 from ops import main
+from tenacity import Retrying, wait_fixed
 
 from core.config import CharmConfig
-from core.state import ApplicationState
+from core.state import ApplicationState, ClusterState, UnitWorkloadState
 from events.cassandra import CassandraEvents
 from managers.cluster import ClusterManager
 from managers.config import ConfigManager
@@ -28,26 +29,42 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
     def __init__(self, *args):
         super().__init__(*args)
 
-        state = ApplicationState(self)
-        workload = CassandraWorkload()
-        cluster_manager = ClusterManager(workload=workload)
-        config_manager = ConfigManager(workload=workload)
+        self.state = ApplicationState(self)
+        self.workload = CassandraWorkload()
+        self.cluster_manager = ClusterManager(workload=self.workload)
+
+        config_manager = ConfigManager(
+            workload=self.workload,
+            cluster_name=self.state.cluster.cluster_name,
+            listen_address=self.state.unit.ip,
+            seeds=self.state.cluster.seeds,
+        )
         bootstrap_manager = RollingOpsManager(
             charm=self, relation="bootstrap", callback=self.bootstrap
         )
 
         self.cassandra_events = CassandraEvents(
             self,
-            state=state,
-            workload=workload,
-            cluster_manager=cluster_manager,
+            state=self.state,
+            workload=self.workload,
+            cluster_manager=self.cluster_manager,
             config_manager=config_manager,
             bootstrap_manager=bootstrap_manager,
         )
 
     def bootstrap(self, event: RunWithLock) -> None:
         """Start workload and join this unit to the cluster."""
-        self.cassandra_events.bootstrap(event)
+        # TODO: add leader elected hook
+        self.state.unit.workload_state = UnitWorkloadState.STARTING
+
+        self.workload.restart()
+
+        for _ in Retrying(wait=wait_fixed(10)):
+            if self.cluster_manager.is_healthy:
+                self.state.unit.workload_state = UnitWorkloadState.ACTIVE
+                if self.unit.is_leader():
+                    self.state.cluster.state = ClusterState.ACTIVE
+                return
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charm definiton."""
+"""Charm definition."""
 
 import logging
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charm the application."""
+"""Charm definiton."""
 
 import logging
 
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class CassandraCharm(TypedCharmBase[CharmConfig]):
-    """Charm the application."""
+    """Application charm."""
 
     config_type = CharmConfig
 

--- a/src/common/cassandra_client.py
+++ b/src/common/cassandra_client.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class CassandraClient:
-    """TODO."""
+    """Cassandra CQL client."""
 
     def __init__(self, hosts: list[str], user: str | None = None, password: str | None = None):
         self.execution_profile = ExecutionProfile(

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charm config definition."""
+"""Charm config."""
 
 from typing import Literal
 
@@ -13,15 +13,15 @@ ConfigProfile = Literal["testing", "production"]
 
 
 class CharmConfig(BaseConfigModel):
-    """Manager for the structured configuration."""
+    """Structured charm config."""
 
-    profile: ConfigProfile
     cluster_name: str
+    profile: ConfigProfile
 
     @field_validator("cluster_name")
     @classmethod
     def cluster_name_values(cls, value: str) -> str:
-        """TODO."""
+        """Validate cluster_name."""
         if len(value) == 0:
             raise ValueError("cluster_name cannot be empty")
 

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -173,7 +173,7 @@ class ClusterContext(RelationState):
 
     @property
     def is_active(self) -> bool:
-        """Is Cassandra cluster state `ACTIVE`."""
+        """Whether Cassandra cluster state is `ACTIVE`."""
         return self.state == ClusterState.ACTIVE
 
 

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -153,6 +153,15 @@ class ClusterContext(RelationState):
         self.app = component
 
     @property
+    def cluster_name(self) -> str:
+        """Established Cassandra cluster name."""
+        return self.relation_data.get("cluster_name", "")
+
+    @cluster_name.setter
+    def cluster_name(self, value: str) -> None:
+        self._field_setter_wrapper("cluster_name", value)
+
+    @property
     def seeds(self) -> list[str]:
         """List of peer urls of Cassandra seed nodes."""
         seeds = self.relation_data.get("seeds", "")

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -5,7 +5,7 @@
 """TODO."""
 
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from charms.data_platform_libs.v0.data_interfaces import (
     Data,
@@ -22,15 +22,17 @@ CLIENT_PORT = 9042
 logger = logging.getLogger(__name__)
 
 
-class ClusterState(Enum):
+class ClusterState(StrEnum):
     """TODO."""
 
+    UNKNOWN = ""
     ACTIVE = "active"
 
 
-class UnitWorkloadState(Enum):
+class UnitWorkloadState(StrEnum):
     """TODO."""
 
+    UNKNOWN = ""
     STARTING = "starting"
     ACTIVE = "active"
 
@@ -122,11 +124,9 @@ class UnitContext(RelationState):
         return f"{self.ip}:{CLIENT_PORT}"
 
     @property
-    def workload_state(self) -> UnitWorkloadState | None:
+    def workload_state(self) -> UnitWorkloadState:
         """TODO."""
-        if not self.relation or not (value := self.relation_data.get("workload_state", "")):
-            return None
-        return UnitWorkloadState[value.upper()]
+        return self.relation_data.get("workload_state", UnitWorkloadState.UNKNOWN)
 
     @workload_state.setter
     def workload_state(self, value: UnitWorkloadState) -> None:
@@ -148,20 +148,17 @@ class ClusterContext(RelationState):
     @property
     def seeds(self) -> list[str]:
         """TODO."""
-        if not self.relation or not (value := self.relation_data.get("seeds", "")):
-            return []
-        return value.split(",")
+        seeds = self.relation_data.get("seeds", "")
+        return seeds.split(",") if seeds else []
 
     @seeds.setter
     def seeds(self, value: list[str]) -> None:
         self._field_setter_wrapper("seeds", ",".join(value))
 
     @property
-    def state(self) -> ClusterState | None:
+    def state(self) -> ClusterState:
         """The cluster state ('new' or 'existing') of the cassandra cluster."""
-        if not self.relation or not (value := self.relation_data.get("cluster_state", "")):
-            return None
-        return ClusterState[value.upper()]
+        return self.relation_data.get("cluster_state", ClusterState.UNKNOWN)
 
     @state.setter
     def state(self, value: ClusterState) -> None:

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -32,7 +32,7 @@ class ClusterState(StrEnum):
 class UnitWorkloadState(StrEnum):
     """TODO."""
 
-    UNKNOWN = ""
+    INSTALLING = ""
     STARTING = "starting"
     ACTIVE = "active"
 
@@ -126,7 +126,7 @@ class UnitContext(RelationState):
     @property
     def workload_state(self) -> UnitWorkloadState:
         """TODO."""
-        return self.relation_data.get("workload_state", UnitWorkloadState.UNKNOWN)
+        return self.relation_data.get("workload_state", UnitWorkloadState.INSTALLING)
 
     @workload_state.setter
     def workload_state(self, value: UnitWorkloadState) -> None:
@@ -164,6 +164,11 @@ class ClusterContext(RelationState):
     def state(self, value: ClusterState) -> None:
         """TODO."""
         self._field_setter_wrapper("cluster_state", value.value)
+
+    @property
+    def active(self) -> bool:
+        """TODO."""
+        return self.state == ClusterState.ACTIVE
 
 
 class ApplicationState(Object):

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -33,6 +33,7 @@ class UnitWorkloadState(StrEnum):
     """TODO."""
 
     INSTALLING = ""
+    WAITING_FOR_START = "waiting_for_start"
     STARTING = "starting"
     ACTIVE = "active"
 
@@ -166,7 +167,7 @@ class ClusterContext(RelationState):
         self._field_setter_wrapper("cluster_state", value.value)
 
     @property
-    def active(self) -> bool:
+    def is_active(self) -> bool:
         """TODO."""
         return self.state == ClusterState.ACTIVE
 

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -122,20 +122,15 @@ class UnitContext(RelationState):
         return f"{self.ip}:{CLIENT_PORT}"
 
     @property
-    def is_started(self) -> bool:
-        """Check if the unit has started."""
-        return self.relation_data.get("state", "") == "started"
-
-    @property
-    def workload_state(self) -> str:
+    def workload_state(self) -> UnitWorkloadState | None:
         """TODO."""
-        if not self.relation:
-            return ""
-        return self.relation_data.get("workload_state", "")
+        if not self.relation or not (value := self.relation_data.get("workload_state", "")):
+            return None
+        return UnitWorkloadState[value.upper()]
 
     @workload_state.setter
-    def workload_state(self, value: str) -> None:
-        self._field_setter_wrapper("workload_state", value)
+    def workload_state(self, value: UnitWorkloadState) -> None:
+        self._field_setter_wrapper("workload_state", value.value)
 
 
 class ClusterContext(RelationState):
@@ -151,14 +146,27 @@ class ClusterContext(RelationState):
         self.app = component
 
     @property
-    def state(self) -> str:
+    def seeds(self) -> list[str]:
+        """TODO."""
+        if not self.relation or not (value := self.relation_data.get("seeds", "")):
+            return []
+        return value.split(",")
+
+    @seeds.setter
+    def seeds(self, value: list[str]) -> None:
+        self._field_setter_wrapper("seeds", ",".join(value))
+
+    @property
+    def state(self) -> ClusterState | None:
         """The cluster state ('new' or 'existing') of the cassandra cluster."""
-        return self.relation_data.get("cluster_state", "")
+        if not self.relation or not (value := self.relation_data.get("cluster_state", "")):
+            return None
+        return ClusterState[value.upper()]
 
     @state.setter
-    def state(self, value: str) -> None:
+    def state(self, value: ClusterState) -> None:
         """TODO."""
-        self._field_setter_wrapper("cluster_state", value)
+        self._field_setter_wrapper("cluster_state", value.value)
 
 
 class ApplicationState(Object):

--- a/src/core/statuses.py
+++ b/src/core/statuses.py
@@ -6,7 +6,7 @@
 
 from enum import Enum
 
-from ops import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 
 class Status(Enum):
@@ -15,4 +15,5 @@ class Status(Enum):
     ACTIVE = ActiveStatus()
     INSTALLING = MaintenanceStatus("installing Cassandra")
     STARTING = MaintenanceStatus("waiting for Cassandra to start")
+    WAITING_FOR_CLUSTER = WaitingStatus("waiting for cluster to start")
     INVALID_CONFIG = BlockedStatus("invalid config")

--- a/src/core/statuses.py
+++ b/src/core/statuses.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""TODO."""
+"""Charm statuses."""
 
 from enum import Enum
 

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -13,7 +13,7 @@ Substrate = Literal["vm", "k8s"]
 
 
 class CassandraPaths:
-    """TODO."""
+    """Filesystem paths of the Cassandra workload."""
 
     env: pathops.PathProtocol
     config_dir: pathops.PathProtocol
@@ -21,96 +21,77 @@ class CassandraPaths:
 
     @property
     def config(self) -> pathops.PathProtocol:
-        """TODO."""
+        """Main config file."""
         return self.config_dir / "cassandra.yaml"
 
     @property
     def commitlog_directory(self) -> pathops.PathProtocol:
-        """TODO."""
+        """Commitlog data directory."""
         return self.data_dir / "commitlog"
 
     @property
     def data_file_directory(self) -> pathops.PathProtocol:
-        """TODO."""
+        """Main data directory."""
         return self.data_dir / "data"
 
     @property
     def hints_directory(self) -> pathops.PathProtocol:
-        """TODO."""
+        """Hints data directory."""
         return self.data_dir / "hints"
 
     @property
     def saved_caches_directory(self) -> pathops.PathProtocol:
-        """TODO."""
+        """Saved caches data directory."""
         return self.data_dir / "saved_caches"
 
 
 class WorkloadBase(ABC):
-    """Base interface for common workload operations."""
+    """Base interface for workload operations."""
 
     substrate: Substrate
     cassandra_paths: CassandraPaths
 
     @abstractmethod
     def start(self) -> None:
-        """Start the workload service."""
+        """Start Cassandra service."""
         pass
 
     @abstractmethod
     def install(self) -> None:
-        """Install the cassandra snap."""
+        """Install Cassandra."""
         pass
 
     @abstractmethod
-    def alive(self) -> bool:
-        """Check if the workload is running.
-
-        Returns:
-            bool: True if the workload is running, False otherwise.
-        """
+    def is_alive(self) -> bool:
+        """Whether Cassandra service running."""
         pass
 
     @abstractmethod
     def stop(self) -> None:
-        """Stop the workload service."""
+        """Stop Cassandra service."""
         pass
 
     @abstractmethod
     def restart(self) -> None:
-        """Restart the workload service."""
+        """Restart Cassandra service."""
         pass
 
     @abstractmethod
     def remove_file(self, file: str) -> None:
-        """Remove a file.
-
-        Args:
-            file (str): Path to the file.
-        """
+        """Remove file."""
         pass
 
     @abstractmethod
     def remove_directory(self, directory: str) -> None:
-        """Remove a directory.
-
-        Args:
-            directory (str): Path to the directory.
-        """
+        """Remove directory recursively."""
         pass
 
     @abstractmethod
     def path_exists(self, path: str) -> bool:
-        """Check if a file or directory exists.
-
-        Args:
-            path (str): Path to the file or directory.
-
-        Returns:
-            bool: True if the file or directory exists, False otherwise.
-        """
+        """Check if file or directory exists."""
         pass
 
     @abstractmethod
     def exec(self, command: list[str], suppress_error_log: bool = False) -> tuple[str, str]:
-        """Run a command on the workload substrate."""
+        """Execute command."""
         pass

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -111,6 +111,6 @@ class WorkloadBase(ABC):
         pass
 
     @abstractmethod
-    def exec(self, command: list[str]) -> tuple[str, str]:
+    def exec(self, command: list[str], suppress_error_log: bool = False) -> tuple[str, str]:
         """Run a command on the workload substrate."""
         pass

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""TODO."""
+"""Workload definition."""
 
 from abc import ABC, abstractmethod
 from typing import Literal

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""TODO."""
+"""Handler for main Cassandra charm events."""
 
 import logging
 
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class CassandraEvents(Object):
-    """Handle all base and cassandra related events."""
+    """Handler for main Cassandra charm events."""
 
     def __init__(
         self,
@@ -152,7 +152,11 @@ class CassandraEvents(Object):
         event.add_status(Status.ACTIVE.value)
 
     def _update_network_address(self) -> bool:
-        """TODO."""
+        """Update hostname & ip in this unit context.
+
+        Returns:
+            whether the hostname or ip changed.
+        """
         old_ip = self.state.unit.ip
         old_hostname = self.state.unit.hostname
         self.state.unit.ip, self.state.unit.hostname = self.cluster_manager.network_address()

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -113,12 +113,12 @@ class CassandraEvents(Object):
         except ValidationError:
             event.add_status(Status.INVALID_CONFIG.value)
 
-        if self.state.unit.workload_state is None:
+        if not self.state.unit.workload_state:
             event.add_status(Status.INSTALLING.value)
 
-        if not self.charm.unit.is_leader() and self.state.cluster.state != ClusterState.ACTIVE:
-            event.add_status(Status.WAITING_FOR_CLUSTER.value)
-        elif self.state.unit.workload_state == UnitWorkloadState.STARTING:
+        if self.state.unit.workload_state == UnitWorkloadState.STARTING:
+            if not self.charm.unit.is_leader() and self.state.cluster.state != ClusterState.ACTIVE:
+                event.add_status(Status.WAITING_FOR_CLUSTER.value)
             event.add_status(Status.STARTING.value)
 
         if self.state.unit.workload_state == UnitWorkloadState.ACTIVE and (

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -65,6 +65,7 @@ class CassandraEvents(Object):
             self.state.unit.workload_state = UnitWorkloadState.WAITING_FOR_START
             logger.debug("Deferring on_start for unit due to cluster isn't initialized yet")
             event.defer()
+            return
 
         try:
             if self.charm.unit.is_leader():

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -126,11 +126,15 @@ class CassandraEvents(Object):
         ):
             event.add_status(Status.STARTING.value)
 
+        event.add_status(Status.ACTIVE.value)
+
     def _on_collect_app_status(self, event: CollectStatusEvent) -> None:
         try:
             self.charm.config
         except ValidationError:
             event.add_status(Status.INVALID_CONFIG.value)
+
+        event.add_status(Status.ACTIVE.value)
 
     def _update_network_address(self) -> bool:
         """TODO."""

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -50,6 +50,7 @@ class CassandraEvents(Object):
         self.framework.observe(self.charm.on.config_changed, self._on_config_changed)
         self.framework.observe(self.charm.on.update_status, self._on_update_status)
         self.framework.observe(self.charm.on.collect_unit_status, self._on_collect_unit_status)
+        self.framework.observe(self.charm.on.collect_app_status, self._on_collect_app_status)
 
     def _on_install(self, _: InstallEvent) -> None:
         self.workload.install()
@@ -124,6 +125,12 @@ class CassandraEvents(Object):
             not self.workload.alive() or not self.cluster_manager.is_healthy
         ):
             event.add_status(Status.STARTING.value)
+
+    def _on_collect_app_status(self, event: CollectStatusEvent) -> None:
+        try:
+            self.charm.config
+        except ValidationError:
+            event.add_status(Status.INVALID_CONFIG.value)
 
     def _update_network_address(self) -> bool:
         """TODO."""

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -53,45 +53,57 @@ class CassandraEvents(Object):
 
     def _on_install(self, _: InstallEvent) -> None:
         self.workload.install()
-        self.state.unit.workload_state = UnitWorkloadState.STARTING.value
+        self.state.unit.workload_state = UnitWorkloadState.STARTING
 
     def _on_start(self, event: StartEvent) -> None:
         self._update_network_address()
-        try:
-            self.config_manager.render_env(
-                cassandra_limit_memory_mb=1024 if self.charm.config.profile == "testing" else None
-            )
-        except ValidationError as e:
-            logger.debug(f"Config haven't passed validation: {e}")
-            event.defer()
-            return
 
-        if (
-            not self.charm.unit.is_leader()
-            and self.state.cluster.state != ClusterState.ACTIVE.value
-        ):
+        if not self.charm.unit.is_leader() and self.state.cluster.state != ClusterState.ACTIVE:
             logger.debug("Deferring on_start for unit due to cluster isn't initialized yet")
             event.defer()
             return
 
-        self.workload.restart()
-        self.state.unit.workload_state = UnitWorkloadState.ACTIVE.value
         if self.charm.unit.is_leader():
-            self.state.cluster.state = ClusterState.ACTIVE.value
+            self.state.cluster.seeds = [self.state.unit.peer_url]
 
-    def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         try:
             self.config_manager.render_env(
                 cassandra_limit_memory_mb=1024 if self.charm.config.profile == "testing" else None
             )
+            self.config_manager.render_cassandra_config(
+                cluster_name=self.charm.config.cluster_name,
+                listen_address=self.state.unit.ip,
+                seeds=self.state.cluster.seeds,
+            )
+        except ValidationError as e:
+            logger.debug(f"Config haven't passed validation: {e}")
+            event.defer()
+            return
+
+        self.workload.start()
+        self.state.unit.workload_state = UnitWorkloadState.ACTIVE
+
+        if self.charm.unit.is_leader():
+            self.state.cluster.state = ClusterState.ACTIVE
+
+    def _on_config_changed(self, _: ConfigChangedEvent) -> None:
+        try:
+            self.config_manager.render_env(
+                cassandra_limit_memory_mb=1024 if self.charm.config.profile == "testing" else None
+            )
+            self.config_manager.render_cassandra_config(
+                cluster_name=self.charm.config.cluster_name,
+                listen_address=self.state.unit.ip,
+                seeds=self.state.cluster.seeds,
+            )
         except ValidationError as e:
             logger.debug(f"Config haven't passed validation: {e}")
             return
-        if not self.state.unit.workload_state == UnitWorkloadState.ACTIVE.value:
+        if not self.state.unit.workload_state == UnitWorkloadState.ACTIVE:
             return
         self.workload.restart()
 
-    def _on_update_status(self, event: UpdateStatusEvent) -> None:
+    def _on_update_status(self, _: UpdateStatusEvent) -> None:
         self._update_network_address()
 
     def _on_collect_unit_status(self, event: CollectStatusEvent) -> None:
@@ -100,13 +112,15 @@ class CassandraEvents(Object):
         except ValidationError:
             event.add_status(Status.INVALID_CONFIG.value)
 
-        if self.state.unit.workload_state == "":
+        if self.state.unit.workload_state is None:
             event.add_status(Status.INSTALLING.value)
 
-        if self.state.unit.workload_state == UnitWorkloadState.STARTING.value:
+        if not self.charm.unit.is_leader() and self.state.cluster.state != ClusterState.ACTIVE:
+            event.add_status(Status.WAITING_FOR_CLUSTER.value)
+        elif self.state.unit.workload_state == UnitWorkloadState.STARTING:
             event.add_status(Status.STARTING.value)
 
-        if self.state.unit.workload_state == UnitWorkloadState.ACTIVE.value and (
+        if self.state.unit.workload_state == UnitWorkloadState.ACTIVE and (
             not self.workload.alive() or not self.cluster_manager.is_healthy
         ):
             event.add_status(Status.STARTING.value)

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -26,7 +26,7 @@ class ClusterManager:
     def is_healthy(self) -> bool:
         """TODO."""
         try:
-            stdout, _ = self._workload.exec([_NODETOOL, "info"])
+            stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
             return "Native Transport active: true" in stdout
         except ExecError:
             return False

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""TODO."""
+"""Cluster manager."""
 
 import logging
 import socket
@@ -16,7 +16,7 @@ _NODETOOL = "charmed-cassandra.nodetool"
 
 
 class ClusterManager:
-    """Manage cluster members, quorum and authorization."""
+    """Manager of Cassandra cluster, including this unit."""
 
     def __init__(self, workload: WorkloadBase):
         self._workload = workload
@@ -24,7 +24,7 @@ class ClusterManager:
 
     @property
     def is_healthy(self) -> bool:
-        """TODO."""
+        """Whether Cassandra healthy and ready in this unit."""
         try:
             stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
             return "Native Transport active: true" in stdout
@@ -32,6 +32,6 @@ class ClusterManager:
             return False
 
     def network_address(self) -> tuple[str, str]:
-        """TODO."""
+        """Get hostname and IP of this unit."""
         hostname = socket.gethostname()
         return socket.gethostbyname(hostname), hostname

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -20,11 +20,20 @@ class ConfigManager:
     def __init__(
         self,
         workload: WorkloadBase,
+        cluster_name: str,
+        listen_address: str,
+        seeds: list[str],
     ):
         self.workload = workload
+        self.cluster_name = cluster_name
+        self.listen_address = listen_address
+        self.seeds = seeds
 
     def render_cassandra_config(
-        self, cluster_name: str, listen_address: str, seeds: list[str]
+        self,
+        cluster_name: str | None = None,
+        listen_address: str | None = None,
+        seeds: list[str] | None = None,
     ) -> None:
         """Generate and write cassandra config."""
         config = {
@@ -33,7 +42,7 @@ class ConfigManager:
             "authorizer": "AllowAllAuthorizer",
             "cas_contention_timeout": "1000ms",
             "cidr_authorizer": {"class_name": "AllowAllCIDRAuthorizer"},
-            "cluster_name": cluster_name,
+            "cluster_name": cluster_name or self.cluster_name,
             "commitlog_directory": self.workload.cassandra_paths.commitlog_directory.as_posix(),
             "commitlog_sync": "periodic",
             "commitlog_sync_period": "10000ms",
@@ -51,7 +60,7 @@ class ConfigManager:
             "hints_directory": self.workload.cassandra_paths.hints_directory.as_posix(),
             "inter_dc_tcp_nodelay": False,
             "internode_compression": "dc",
-            "listen_address": listen_address,
+            "listen_address": listen_address or self.listen_address,
             "memtable": {
                 "configurations": {
                     "default": {"inherits": "skiplist"},
@@ -68,14 +77,14 @@ class ConfigManager:
                 "cached_rows_warn_threshold": 2000,
             },
             "role_manager": "CassandraRoleManager",
-            "rpc_address": listen_address,
+            "rpc_address": listen_address or self.listen_address,
             "saved_caches_directory": (
                 self.workload.cassandra_paths.saved_caches_directory.as_posix()
             ),
             "seed_provider": [
                 {
                     "class_name": "org.apache.cassandra.locator.SimpleSeedProvider",
-                    "parameters": [{"seeds": ",".join(seeds)}],
+                    "parameters": [{"seeds": ",".join(seeds or self.seeds)}],
                 }
             ],
             "storage_compatibility_mode": "CASSANDRA_4",

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Manager for handling configuration building + writing."""
+"""Config manager."""
 
 import logging
 from typing import Iterable
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigManager:
-    """Handle the configuration of Cassandra."""
+    """Manager of config files."""
 
     def __init__(
         self,
@@ -26,7 +26,7 @@ class ConfigManager:
     def render_cassandra_config(
         self, cluster_name: str, listen_address: str, seeds: list[str]
     ) -> None:
-        """TODO."""
+        """Generate and write cassandra config."""
         config = {
             "allocate_tokens_for_local_replication_factor": 3,
             "authenticator": "AllowAllAuthenticator",
@@ -87,7 +87,7 @@ class ConfigManager:
         )
 
     def render_env(self, cassandra_limit_memory_mb: int | None) -> None:
-        """TODO."""
+        """Update environment config."""
         self.workload.cassandra_paths.env.write_text(
             self._render_env(
                 [

--- a/src/workload.py
+++ b/src/workload.py
@@ -51,7 +51,6 @@ class CassandraWorkload(WorkloadBase):
 
     @override
     def install(self) -> None:
-        """Install the cassandra snap."""
         logger.debug("Installing & configuring Cassandra snap")
         self._cassandra_snap.ensure(snap.SnapState.Present, revision=SNAP_REVISION)
         self._cassandra_snap.connect("process-control")
@@ -60,7 +59,7 @@ class CassandraWorkload(WorkloadBase):
         self._cassandra_snap.hold()
 
     @override
-    def alive(self) -> bool:
+    def is_alive(self) -> bool:
         try:
             return bool(self._cassandra_snap.services[SNAP_SERVICE]["active"])
         except KeyError:

--- a/src/workload.py
+++ b/src/workload.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""TODO."""
+"""Workload VM Implementation."""
 
 import logging
 import subprocess

--- a/src/workload.py
+++ b/src/workload.py
@@ -96,7 +96,7 @@ class CassandraWorkload(WorkloadBase):
         return False
 
     @override
-    def exec(self, command: list[str]) -> tuple[str, str]:
+    def exec(self, command: list[str], suppress_error_log: bool = False) -> tuple[str, str]:
         try:
             result = subprocess.run(
                 command,
@@ -114,18 +114,20 @@ class CassandraWorkload(WorkloadBase):
         except subprocess.CalledProcessError as e:
             stdout = e.stdout.strip()
             stderr = e.stderr.strip()
-            logger.error(
-                "Got non-zero return code %s while executing command: %s",
-                e.returncode,
-                " ".join(command),
-            )
+            if not suppress_error_log:
+                logger.error(
+                    "Got non-zero return code %s while executing command: %s",
+                    e.returncode,
+                    " ".join(command),
+                )
             logger.debug("STDOUT: %s", e.stdout.strip())
             logger.debug("STDERR: %s", e.stderr.strip())
             raise ExecError(e.stdout.strip(), e.stderr.strip())
         except subprocess.TimeoutExpired as e:
             stdout = e.stdout.decode().strip() if e.stdout else ""
             stderr = e.stderr.decode().strip() if e.stderr else ""
-            logger.error("Got timeout error while executing command: %s", " ".join(command))
+            if not suppress_error_log:
+                logger.error("Got timeout error while executing command: %s", " ".join(command))
             logger.debug("STDOUT: %s", stdout)
             logger.debug("STDERR: %s", stderr)
             raise ExecError(stdout, stderr)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ from typing import Generator
 
 import jubilant
 import pytest
+import yaml
 
 
 @pytest.fixture(scope="module")
@@ -39,3 +40,9 @@ def cassandra_charm() -> Path:
         raise FileNotFoundError("Could not find packed cassandra charm.")
 
     return path
+
+
+@pytest.fixture(scope="module")
+def app_name() -> str:
+    metadata = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+    return metadata["name"]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from contextlib import contextmanager
+from typing import Generator
+
+from cassandra.auth import PlainTextAuthProvider
+from cassandra.cluster import EXEC_PROFILE_DEFAULT, Cluster, ExecutionProfile, Session
+from cassandra.policies import DCAwareRoundRobinPolicy, TokenAwarePolicy
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def connect_cql(
+    hosts: list[str],
+    user: str | None = None,
+    password: str | None = None,
+    keyspace: str | None = None,
+    timeout: float | None = None,
+) -> Generator[Session, None, None]:
+    execution_profile = ExecutionProfile(
+        load_balancing_policy=TokenAwarePolicy(DCAwareRoundRobinPolicy()),
+        request_timeout=timeout or 10,
+    )
+    auth_provider = (
+        PlainTextAuthProvider(username=user, password=password)
+        if user is not None and password is not None
+        else None
+    )
+    cluster = Cluster(
+        auth_provider=auth_provider,
+        contact_points=hosts,
+        protocol_version=5,
+        execution_profiles={EXEC_PROFILE_DEFAULT: execution_profile},
+    )
+    session = cluster.connect()
+    if keyspace:
+        session.set_keyspace(keyspace)
+    try:
+        yield session
+    finally:
+        cluster.shutdown()

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+
+import jubilant
+from cassandra.cluster import ResultSet
+from helpers import connect_cql
+
+logger = logging.getLogger(__name__)
+
+
+def test_deploy_bad_config(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> None:
+    juju.deploy(
+        cassandra_charm,
+        app=app_name,
+        config={"profile": "bad_value"},
+        num_units=1,
+    )
+    juju.wait(jubilant.all_blocked)
+
+
+def test_deploy_resolve_config(juju: jubilant.Juju, app_name: str) -> None:
+    juju.config(app_name, values={"profile": "testing"})
+    juju.wait(jubilant.all_active)
+
+
+def test_write(juju: jubilant.Juju, app_name: str) -> None:
+    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
+    with connect_cql(hosts=[host], timeout=300) as session:
+        session.execute(
+            "CREATE KEYSPACE test "
+            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}",
+        )
+        session.set_keyspace("test")
+        session.execute("CREATE TABLE test(message TEXT PRIMARY KEY)")
+        session.execute("INSERT INTO test(message) VALUES ('hello')")
+
+
+def test_read(juju: jubilant.Juju, app_name: str) -> None:
+    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
+    with connect_cql(hosts=[host], keyspace="test") as session:
+        res = session.execute("SELECT message FROM test")
+        assert (
+            isinstance(res, ResultSet)
+            and len(res_list := res.all()) == 1
+            and res_list[0].message == "hello"
+        ), "test data written prior aren't found"
+
+
+def test_bad_config(juju: jubilant.Juju, app_name: str) -> None:
+    juju.config(app_name, values={"profile": "bad_value"})
+    juju.wait(jubilant.all_blocked)
+
+
+def test_read_bad_config(juju: jubilant.Juju, app_name: str) -> None:
+    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
+    with connect_cql(hosts=[host], keyspace="test") as session:
+        res = session.execute("SELECT message FROM test")
+        assert (
+            isinstance(res, ResultSet)
+            and len(res_list := res.all()) == 1
+            and res_list[0].message == "hello"
+        ), "test data written prior aren't found"
+
+
+def test_resolve_config(juju: jubilant.Juju, app_name: str) -> None:
+    juju.config(app_name, values={"profile": "testing"})
+    juju.wait(jubilant.all_active)
+
+
+def test_read_after_resolve(juju: jubilant.Juju, app_name: str) -> None:
+    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
+    with connect_cql(hosts=[host], keyspace="test") as session:
+        res = session.execute("SELECT message FROM test")
+        assert (
+            isinstance(res, ResultSet)
+            and len(res_list := res.all()) == 1
+            and res_list[0].message == "hello"
+        ), "test data written prior aren't found"

--- a/tests/integration/test_multinode.py
+++ b/tests/integration/test_multinode.py
@@ -17,16 +17,17 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
         cassandra_charm,
         app=app_name,
         config={"profile": "testing"},
+        num_units=3,
     )
     juju.wait(jubilant.all_active)
 
 
 def test_write(juju: jubilant.Juju, app_name: str) -> None:
     host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(hosts=[host]) as session:
+    with connect_cql(hosts=[host], timeout=300) as session:
         session.execute(
             "CREATE KEYSPACE test "
-            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}",
         )
         session.set_keyspace("test")
         session.execute("CREATE TABLE test(message TEXT PRIMARY KEY)")
@@ -34,9 +35,9 @@ def test_write(juju: jubilant.Juju, app_name: str) -> None:
 
 
 def test_read(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
+    host = juju.status().apps[app_name].units[f"{app_name}/2"].public_address
     with connect_cql(hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test")
+        res = session.execute("SELECT message FROM test", timeout=300)
         assert (
             isinstance(res, ResultSet)
             and len(res_list := res.all()) == 1

--- a/tests/integration/test_multinode.py
+++ b/tests/integration/test_multinode.py
@@ -19,7 +19,7 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
         config={"profile": "testing"},
         num_units=3,
     )
-    juju.wait(jubilant.all_active)
+    juju.wait(jubilant.all_active, timeout=1000)
 
 
 def test_write(juju: jubilant.Juju, app_name: str) -> None:

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -17,16 +17,17 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
         cassandra_charm,
         app=app_name,
         config={"profile": "testing"},
+        num_units=1,
     )
     juju.wait(jubilant.all_active)
 
 
 def test_write(juju: jubilant.Juju, app_name: str) -> None:
     host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(hosts=[host]) as session:
+    with connect_cql(hosts=[host], timeout=300) as session:
         session.execute(
             "CREATE KEYSPACE test "
-            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}",
         )
         session.set_keyspace("test")
         session.execute("CREATE TABLE test(message TEXT PRIMARY KEY)")
@@ -36,9 +37,32 @@ def test_write(juju: jubilant.Juju, app_name: str) -> None:
 def test_read(juju: jubilant.Juju, app_name: str) -> None:
     host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
     with connect_cql(hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test")
+        res = session.execute("SELECT message FROM test", timeout=300)
         assert (
             isinstance(res, ResultSet)
             and len(res_list := res.all()) == 1
             and res_list[0].message == "hello"
+        ), "test data written prior aren't found"
+
+
+def test_scale(juju: jubilant.Juju, app_name: str) -> None:
+    juju.add_unit(app_name, num_units=2)
+    juju.wait(jubilant.all_active)
+
+
+def test_write_multinode(juju: jubilant.Juju, app_name: str) -> None:
+    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
+    with connect_cql(hosts=[host], timeout=300, keyspace="test") as session:
+        session.execute("INSERT INTO test(message) VALUES ('world')")
+
+
+def test_read_multinode(juju: jubilant.Juju, app_name: str) -> None:
+    host = juju.status().apps[app_name].units[f"{app_name}/2"].public_address
+    with connect_cql(hosts=[host], keyspace="test") as session:
+        res = session.execute("SELECT message FROM test", timeout=300)
+        assert (
+            isinstance(res, ResultSet)
+            and len(res_list := res.all()) == 2
+            and res_list[0].message == "hello"
+            and res_list[1].message == "world"
         ), "test data written prior aren't found"

--- a/tests/spread/test_charm.py/task.yaml
+++ b/tests/spread/test_charm.py/task.yaml
@@ -1,7 +1,6 @@
 summary: test_charm.py
-environment:
-  TEST_MODULE: test_charm.py
 execute: |
-  tox run -e integration-charm -- "tests/integration/$TEST_MODULE" --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration-charm -- --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+

--- a/tests/spread/test_config.py/task.yaml
+++ b/tests/spread/test_config.py/task.yaml
@@ -1,0 +1,5 @@
+summary: test_config.py
+execute: |
+  tox run -e integration-config -- --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_multinode.py/task.yaml
+++ b/tests/spread/test_multinode.py/task.yaml
@@ -1,0 +1,5 @@
+summary: test_multinode.py
+execute: |
+  tox run -e integration-multinode -- --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_scaling.py/task.yaml
+++ b/tests/spread/test_scaling.py/task.yaml
@@ -1,0 +1,5 @@
+summary: test_scaling.py
+execute: |
+  tox run -e integration-scaling -- --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,84 +11,37 @@ from ops import testing
 from charm import CassandraCharm
 from core.state import PEER_RELATION
 
+BOOTSTRAP_RELATION = "bootstrap"
 
-def test_start_maintenance_status():
-    """Charm enters MaintenanceStatus when Cassandra is not yet healthy."""
+
+def test_start_leader():
+    """Leader should render all required configs and start workload."""
     ctx = testing.Context(CassandraCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
-    state = testing.State(leader=True, relations={relation})
+    bootstrap_relation = testing.PeerRelation(id=2, endpoint=BOOTSTRAP_RELATION)
+    state = testing.State(leader=True, relations={relation, bootstrap_relation})
 
     with (
-        patch("managers.config.ConfigManager.render_env"),
-        patch("managers.config.ConfigManager.render_cassandra_config"),
-        patch("charm.CassandraWorkload"),
-        patch(
-            "managers.cluster.ClusterManager.is_healthy",
-            new_callable=PropertyMock(return_value=False),
-        ),
-    ):
-        state = ctx.run(ctx.on.start(), state)
-        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
-        assert not state.get_relation(1).local_app_data.get("cluster_state")
-
-        state = ctx.run(ctx.on.update_status(), state)
-        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
-        assert not state.get_relation(1).local_app_data.get("cluster_state")
-
-
-def test_start_active_status_when_healthy():
-    """Charm enters ActiveStatus when Cassandra is healthy after start."""
-    ctx = testing.Context(CassandraCharm)
-    relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
-    state = testing.State(leader=True, relations={relation})
-
-    with (
-        patch("managers.config.ConfigManager.render_env"),
-        patch("managers.config.ConfigManager.render_cassandra_config"),
-        patch("charm.CassandraWorkload"),
+        patch("managers.config.ConfigManager.render_env") as render_env,
+        patch("managers.config.ConfigManager.render_cassandra_config") as render_cassandra_config,
+        patch("charm.CassandraWorkload") as workload,
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=True),
         ),
     ):
         state = ctx.run(ctx.on.start(), state)
-        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
-        assert not state.get_relation(1).local_app_data.get("cluster_state")
-
-        state = ctx.run(ctx.on.update_status(), state)
+        render_env.assert_called()
+        render_cassandra_config.assert_called()
+        workload.return_value.restart.assert_called_once()
         assert state.unit_status == ops.ActiveStatus()
-        assert state.get_relation(1).local_unit_data.get("workload_state") == "active"
-        assert state.get_relation(1).local_app_data.get("cluster_state") == "active"
 
 
-def test_start_only_after_leader_active():
-    """Ensure Cassandra node starts only after leader is active and cluster_state is 'active'."""
+def test_start_subordinate_only_after_leader_active():
+    """Subordinate should start only after leader initialized cluster."""
     ctx = testing.Context(CassandraCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
     state = testing.State(leader=False, relations={relation})
-
-    with (
-        patch("managers.config.ConfigManager.render_env"),
-        patch("managers.config.ConfigManager.render_cassandra_config"),
-        patch("charm.CassandraWorkload") as workload,
-        patch(
-            "managers.cluster.ClusterManager.is_healthy",
-            new_callable=PropertyMock(return_value=False),
-        ),
-    ):
-        state = ctx.run(ctx.on.start(), state)
-        assert state.unit_status == ops.WaitingStatus("waiting for cluster to start")
-        assert state.get_relation(1).local_unit_data.get("workload_state") == "waiting_for_start"
-        workload.return_value.start.assert_not_called()
-
-    relation = testing.PeerRelation(
-        id=1, endpoint=PEER_RELATION, local_app_data={"cluster_state": "active"}
-    )
-    bootstrap_relation = testing.PeerRelation(id=2, endpoint="bootstrap")
-    state = testing.State(leader=False, relations={relation, bootstrap_relation})
 
     with (
         patch("managers.config.ConfigManager.render_env"),
@@ -99,13 +52,42 @@ def test_start_only_after_leader_active():
         ) as bootstrap,
     ):
         state = ctx.run(ctx.on.start(), state)
-        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
+        bootstrap.assert_not_called()
+
+        relation = testing.PeerRelation(
+            id=1, endpoint=PEER_RELATION, local_app_data={"cluster_state": "active"}
+        )
+        state = testing.State(leader=False, relations={relation})
+
+        state = ctx.run(ctx.on.start(), state)
         bootstrap.assert_called_once()
 
 
+def test_start_invalid_config():
+    """Both leader and subordinate should wait for config to be fixed prior starting workload."""
+    ctx = testing.Context(CassandraCharm)
+    relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+    state = testing.State(leader=True, relations={relation}, config={"profile": "invalid"})
+
+    with (
+        patch("managers.config.ConfigManager.render_env"),
+        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("charm.CassandraWorkload") as workload,
+        patch(
+            "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", autospec=True
+        ) as bootstrap,
+    ):
+        state = ctx.run(ctx.on.start(), state)
+        workload.return_value.restart.assert_not_called()
+
+        state = testing.State(leader=False, relations={relation})
+
+        state = ctx.run(ctx.on.start(), state)
+        bootstrap.assert_not_called()
+
+
 def test_config_changed_invalid_config():
-    """Ensure charm enters BlockedStatus if config is invalid during config_changed event."""
+    """Charm should enter BlockedStatus if config is invalid during config_changed event."""
     ctx = testing.Context(CassandraCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
     state = testing.State(leader=True, relations={relation}, config={"profile": "invalid"})
@@ -119,18 +101,30 @@ def test_config_changed_invalid_config():
         assert state.unit_status == ops.BlockedStatus("invalid config")
 
 
-def test_config_changed_no_restart():
-    """Ensure node is not restarted if workload_state is 'starting' during config_changed event."""
+def test_config_changed():
+    """Charm should restart workload only if it's active when config is changed."""
     ctx = testing.Context(CassandraCharm)
-    relation = testing.PeerRelation(
-        id=1, endpoint=PEER_RELATION, local_unit_data={"workload_state": "starting"}
-    )
-    state = testing.State(leader=True, relations={relation})
+    relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+    bootstrap_relation = testing.PeerRelation(id=2, endpoint=BOOTSTRAP_RELATION)
+    state = testing.State(leader=True, relations={relation, bootstrap_relation})
     with (
-        patch("managers.config.ConfigManager.render_env"),
-        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("managers.config.ConfigManager.render_env") as render_env,
         patch("charm.CassandraWorkload") as workload,
+        patch(
+            "managers.cluster.ClusterManager.is_healthy",
+            new_callable=PropertyMock(return_value=True),
+        ),
     ):
         state = ctx.run(ctx.on.config_changed(), state)
-        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
+        render_env.assert_called()
         workload.return_value.restart.assert_not_called()
+
+        relation = testing.PeerRelation(
+            id=1, endpoint=PEER_RELATION, local_unit_data={"workload_state": "active"}
+        )
+        state = testing.State(leader=True, relations={relation, bootstrap_relation})
+
+        render_env.reset_mock()
+        state = ctx.run(ctx.on.config_changed(), state)
+        render_env.assert_called()
+        workload.return_value.restart.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,7 +21,7 @@ def test_start_maintenance_status_when_starting():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
@@ -42,7 +42,7 @@ def test_start_sets_active_status_when_healthy():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=True),
@@ -63,7 +63,7 @@ def test_start_only_after_leader_active():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
@@ -81,7 +81,7 @@ def test_start_only_after_leader_active():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
@@ -101,7 +101,7 @@ def test_config_changed_invalid_config():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
@@ -121,7 +121,7 @@ def test_config_changed_no_restart():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
@@ -144,7 +144,7 @@ def test_collect_unit_status_active_but_not_healthy():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
@@ -164,7 +164,7 @@ def test_start_not_leader_and_cluster_state_not_active():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.alive"),
+        patch("workload.CassandraWorkload.is_alive"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,103 +12,111 @@ from charm import CassandraCharm
 from core.state import PEER_RELATION
 
 
-def test_start_maintenance_status_when_starting():
+def test_start_maintenance_status():
     """Charm enters MaintenanceStatus when Cassandra is not yet healthy."""
     ctx = testing.Context(CassandraCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
-    state_in = testing.State(leader=True, relations={relation})
+    state = testing.State(leader=True, relations={relation})
 
     with (
         patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.is_alive"),
+        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("charm.CassandraWorkload"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
         ),
     ):
-        state_out = ctx.run(ctx.on.start(), state_in)
-        assert state_out.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-        assert state_out.get_relation(1).local_unit_data.get("workload_state") == "active"
-        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "active"
+        state = ctx.run(ctx.on.start(), state)
+        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
+        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
+        assert not state.get_relation(1).local_app_data.get("cluster_state")
+
+        state = ctx.run(ctx.on.update_status(), state)
+        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
+        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
+        assert not state.get_relation(1).local_app_data.get("cluster_state")
 
 
-def test_start_sets_active_status_when_healthy():
+def test_start_active_status_when_healthy():
     """Charm enters ActiveStatus when Cassandra is healthy after start."""
     ctx = testing.Context(CassandraCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
-    state_in = testing.State(leader=True, relations={relation})
+    state = testing.State(leader=True, relations={relation})
 
     with (
         patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.is_alive"),
+        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("charm.CassandraWorkload"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=True),
         ),
     ):
-        state_out = ctx.run(ctx.on.start(), state_in)
-        assert state_out.unit_status == ops.ActiveStatus()
-        assert state_out.get_relation(1).local_unit_data.get("workload_state") == "active"
-        assert state_out.get_relation(1).local_app_data.get("cluster_state") == "active"
+        state = ctx.run(ctx.on.start(), state)
+        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
+        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
+        assert not state.get_relation(1).local_app_data.get("cluster_state")
+
+        state = ctx.run(ctx.on.update_status(), state)
+        assert state.unit_status == ops.ActiveStatus()
+        assert state.get_relation(1).local_unit_data.get("workload_state") == "active"
+        assert state.get_relation(1).local_app_data.get("cluster_state") == "active"
 
 
 def test_start_only_after_leader_active():
     """Ensure Cassandra node starts only after leader is active and cluster_state is 'active'."""
     ctx = testing.Context(CassandraCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
-    state_in = testing.State(leader=False, relations={relation})
+    state = testing.State(leader=False, relations={relation})
 
     with (
         patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.is_alive"),
+        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("charm.CassandraWorkload") as workload,
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
         ),
     ):
-        state_out = ctx.run(ctx.on.start(), state_in)
-        assert state_out.unit_status == ops.MaintenanceStatus("installing Cassandra")
-        restart.assert_not_called()
+        state = ctx.run(ctx.on.start(), state)
+        assert state.unit_status == ops.WaitingStatus("waiting for cluster to start")
+        assert state.get_relation(1).local_unit_data.get("workload_state") == "waiting_for_start"
+        workload.return_value.start.assert_not_called()
 
     relation = testing.PeerRelation(
         id=1, endpoint=PEER_RELATION, local_app_data={"cluster_state": "active"}
     )
-    state_in = testing.State(leader=False, relations={relation})
+    state = testing.State(leader=False, relations={relation})
 
     with (
         patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.is_alive"),
+        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("charm.CassandraWorkload") as workload,
         patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=False),
         ),
     ):
-        state_out = ctx.run(ctx.on.start(), state_in)
-        assert state_out.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-        assert state_out.get_relation(1).local_unit_data.get("workload_state") == "active"
-        restart.assert_called()
+        state = ctx.run(ctx.on.start(), state)
+        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
+        assert state.get_relation(1).local_unit_data.get("workload_state") == "starting"
+        workload.return_value.start.assert_called()
 
 
 def test_config_changed_invalid_config():
     """Ensure charm enters BlockedStatus if config is invalid during config_changed event."""
     ctx = testing.Context(CassandraCharm)
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
-    state_in = testing.State(leader=True, relations={relation}, config={"profile": "invalid"})
+    state = testing.State(leader=True, relations={relation}, config={"profile": "invalid"})
+
     with (
         patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.is_alive"),
-        patch(
-            "managers.cluster.ClusterManager.is_healthy",
-            new_callable=PropertyMock(return_value=False),
-        ),
+        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("charm.CassandraWorkload"),
     ):
-        state_out = ctx.run(ctx.on.config_changed(), state_in)
-        assert state_out.unit_status == ops.BlockedStatus("invalid config")
+        state = ctx.run(ctx.on.config_changed(), state)
+        assert state.unit_status == ops.BlockedStatus("invalid config")
 
 
 def test_config_changed_no_restart():
@@ -117,59 +125,12 @@ def test_config_changed_no_restart():
     relation = testing.PeerRelation(
         id=1, endpoint=PEER_RELATION, local_unit_data={"workload_state": "starting"}
     )
-    state_in = testing.State(leader=True, relations={relation})
+    state = testing.State(leader=True, relations={relation})
     with (
         patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.is_alive"),
-        patch(
-            "managers.cluster.ClusterManager.is_healthy",
-            new_callable=PropertyMock(return_value=False),
-        ),
+        patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch("charm.CassandraWorkload") as workload,
     ):
-        state_out = ctx.run(ctx.on.config_changed(), state_in)
-        assert state_out.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-        restart.assert_not_called()
-
-
-def test_collect_unit_status_active_but_not_healthy():
-    """Ensure unit is MaintenanceStatus if workload_state is 'active' but node is not healthy."""
-    ctx = testing.Context(CassandraCharm)
-    relation = testing.PeerRelation(
-        id=1,
-        endpoint=PEER_RELATION,
-        local_unit_data={"workload_state": "active"},
-    )
-    state_in = testing.State(leader=True, relations={relation})
-    with (
-        patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart"),
-        patch("workload.CassandraWorkload.is_alive"),
-        patch(
-            "managers.cluster.ClusterManager.is_healthy",
-            new_callable=PropertyMock(return_value=False),
-        ),
-    ):
-        state_out = ctx.run(ctx.on.collect_unit_status(), state_in)
-        assert state_out.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
-
-
-def test_start_not_leader_and_cluster_state_not_active():
-    """Ensure charm does not start Cassandra if not leader and cluster_state is not 'active'."""
-    ctx = testing.Context(CassandraCharm)
-    relation = testing.PeerRelation(
-        id=1, endpoint=PEER_RELATION, local_app_data={"cluster_state": "pending"}
-    )
-    state_in = testing.State(leader=False, relations={relation})
-    with (
-        patch("managers.config.ConfigManager.render_env"),
-        patch("workload.CassandraWorkload.restart") as restart,
-        patch("workload.CassandraWorkload.is_alive"),
-        patch(
-            "managers.cluster.ClusterManager.is_healthy",
-            new_callable=PropertyMock(return_value=False),
-        ),
-    ):
-        state_out = ctx.run(ctx.on.start(), state_in)
-        assert state_out.unit_status == ops.MaintenanceStatus("installing Cassandra")
-        restart.assert_not_called()
+        state = ctx.run(ctx.on.config_changed(), state)
+        assert state.unit_status == ops.MaintenanceStatus("waiting for Cassandra to start")
+        workload.return_value.restart.assert_not_called()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,102 +1,29 @@
-import tempfile
-from pathlib import Path
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import pytest
+
+from unittest.mock import MagicMock
 
 from managers.config import ConfigManager
 
 
-class MockCassandraPaths:
-    """Mock object for cassandra paths."""
+def test_render_env_preserves_existing_vars():
+    """`render_env` should preserve existing environment variables."""
+    workload = MagicMock(cassandra_paths=MagicMock(env=MagicMock()))
+    config_manager = ConfigManager(workload=workload, cluster_name="", listen_address="", seeds=[])
 
-    def __init__(self, temp_dir: Path):
-        self.commitlog_directory = temp_dir / "commitlog"
-        self.data_file_directory = temp_dir / "data"
-        self.hints_directory = temp_dir / "hints"
-        self.saved_caches_directory = temp_dir / "caches"
-        self.config = temp_dir / "cassandra.yaml"
-        self.env = temp_dir / "cassandra-env.sh"
+    workload.cassandra_paths.env.read_text.return_value = (
+        "EXTRA_VAR=extra_value\nPATH=/custom/path\n"
+    )
 
-        # Create directories and files
-        for directory in [
-            self.commitlog_directory,
-            self.data_file_directory,
-            self.hints_directory,
-            self.saved_caches_directory,
-        ]:
-            directory.mkdir(parents=True, exist_ok=True)
+    config_manager.render_env(cassandra_limit_memory_mb=1024)
 
-        # Create initial env file
-        self.env.write_text("EXISTING_VAR=existing_value\nANOTHER_VAR=another_value\n")
-
-
-class MockWorkload:
-    """Mock workload for testing."""
-
-    def __init__(self, temp_dir: Path):
-        self.cassandra_paths = MockCassandraPaths(temp_dir)
-
-
-@pytest.fixture
-def temp_workload():
-    """Create temporary workload for testing."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-        workload = MockWorkload(temp_path)
-        yield workload
-
-
-@pytest.fixture
-def config_manager(temp_workload):
-    """Create ConfigManager instance."""
-    return ConfigManager(temp_workload)
-
-
-def test_render_env_with_memory_limit(config_manager):
-    """Test env rendering with memory limit."""
-    config_manager.render_env(cassandra_limit_memory_mb=2048)
-
-    env_content = config_manager.workload.cassandra_paths.env.read_text()
-
-    assert "EXISTING_VAR=existing_value" in env_content
-    assert "ANOTHER_VAR=another_value" in env_content
-
-    assert "MAX_HEAP_SIZE=2048M" in env_content
-    assert "HEAP_NEWSIZE=1024M" in env_content
-
-    # Change limits
-
-    config_manager.render_env(cassandra_limit_memory_mb=4096)
-
-    env_content = config_manager.workload.cassandra_paths.env.read_text()
-
-    assert "EXISTING_VAR=existing_value" in env_content
-    assert "ANOTHER_VAR=another_value" in env_content
-
-    assert "MAX_HEAP_SIZE=4096M" in env_content
-    assert "HEAP_NEWSIZE=2048M" in env_content
-
-    assert "MAX_HEAP_SIZE=2048M" not in env_content
-    assert "HEAP_NEWSIZE=1024M" not in env_content
-
-
-def test_render_env_preserves_existing_vars(config_manager):
-    """Test that render_env preserves existing environment variables."""
-    # Add some extra variables to the env file
-    original_content = config_manager.workload.cassandra_paths.env.read_text()
-    extra_content = original_content + "EXTRA_VAR=extra_value\nPATH=/custom/path\n"
-    config_manager.workload.cassandra_paths.env.write_text(extra_content)
-
-    config_manager.render_env(cassandra_limit_memory_mb=2048)
-
-    final_content = config_manager.workload.cassandra_paths.env.read_text()
-
-    # All original variables should be preserved
-    assert "EXISTING_VAR=existing_value" in final_content
-    assert "ANOTHER_VAR=another_value" in final_content
-    assert "EXTRA_VAR=extra_value" in final_content
-    assert "PATH=/custom/path" in final_content
-
-    # New heap variables should be added
-    assert "MAX_HEAP_SIZE=2048M" in final_content
-    assert "HEAP_NEWSIZE=1024M" in final_content
+    workload.cassandra_paths.env.read_text.assert_called()
+    workload.cassandra_paths.env.write_text.assert_called()
+    result = workload.cassandra_paths.env.write_text.call_args[0][0]
+    assert "EXTRA_VAR=extra_value" in result
+    assert "PATH=/custom/path" in result
+    assert "MAX_HEAP_SIZE=1024M" in result
+    assert "HEAP_NEWSIZE=512M" in result

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -1,4 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
 import subprocess
+from contextlib import contextmanager
+from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,28 +14,29 @@ from common.exceptions import ExecError
 from workload import SNAP_NAME, SNAP_SERVICE, CassandraWorkload
 
 
-@pytest.fixture
-def mock_snap_cache():
-    with patch("workload.snap.SnapCache") as snap_cache:
-        mock_snap = MagicMock()
-        mock_snap.services = {SNAP_SERVICE: {"active": True}}
-        snap_cache.return_value = {SNAP_NAME: mock_snap}
-        yield mock_snap
+@contextmanager
+def snap_cache(service: bool = False) -> Generator[MagicMock, None, None]:
+    with patch(
+        "workload.snap.SnapCache",
+        return_value={
+            SNAP_NAME: MagicMock(services={SNAP_SERVICE: {"active": True}} if service else {})
+        },
+    ) as snap_cache:
+        yield snap_cache
 
 
-def test_alive_true_if_service_active(mock_snap_cache):
-    workload = CassandraWorkload()
-    assert workload.is_alive() is True
+def test_alive_true_if_service_active():
+    with snap_cache(service=True):
+        assert CassandraWorkload().is_alive()
 
 
-def test_alive_false_if_service_missing(mock_snap_cache):
-    mock_snap_cache.services = {}  # simulate service not found
-    workload = CassandraWorkload()
-    assert workload.is_alive() is False
+def test_alive_false_if_service_missing():
+    with snap_cache():
+        assert not CassandraWorkload().is_alive()
 
 
-def test_exec_successful_command_returns_output(mock_snap_cache):
-    with patch("workload.subprocess.run") as mock_run:
+def test_exec_successful_command_returns_output():
+    with snap_cache(), patch("workload.subprocess.run") as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=["echo", "hello"], returncode=0, stdout="hello\n", stderr=""
         )
@@ -38,8 +46,8 @@ def test_exec_successful_command_returns_output(mock_snap_cache):
         assert stderr == ""
 
 
-def test_exec_command_raises_on_failure(mock_snap_cache):
-    with patch("workload.subprocess.run") as mock_run:
+def test_exec_command_raises_on_failure():
+    with snap_cache(), patch("workload.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1, cmd=["false"], output="", stderr="error"
         )

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -18,13 +18,13 @@ def mock_snap_cache():
 
 def test_alive_true_if_service_active(mock_snap_cache):
     workload = CassandraWorkload()
-    assert workload.alive() is True
+    assert workload.is_alive() is True
 
 
 def test_alive_false_if_service_missing(mock_snap_cache):
     mock_snap_cache.services = {}  # simulate service not found
     workload = CassandraWorkload()
-    assert workload.alive() is False
+    assert workload.is_alive() is False
 
 
 def test_exec_successful_command_returns_output():

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -27,7 +27,7 @@ def test_alive_false_if_service_missing(mock_snap_cache):
     assert workload.is_alive() is False
 
 
-def test_exec_successful_command_returns_output():
+def test_exec_successful_command_returns_output(mock_snap_cache):
     with patch("workload.subprocess.run") as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=["echo", "hello"], returncode=0, stdout="hello\n", stderr=""
@@ -38,7 +38,7 @@ def test_exec_successful_command_returns_output():
         assert stderr == ""
 
 
-def test_exec_command_raises_on_failure():
+def test_exec_command_raises_on_failure(mock_snap_cache):
     with patch("workload.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1, cmd=["false"], output="", stderr="error"

--- a/tox.ini
+++ b/tox.ini
@@ -67,12 +67,14 @@ commands =
                  {[vars]tests_path}/unit
     poetry run coverage report
 
-[testenv:integration-{charm}]
+[testenv:integration-{charm,multinode,scaling}]
 description = Run integration tests
 pass_env =
     CI
 set_env =
     charm: TESTFILE=test_charm.py
+    multinode: TESTFILE=test_multinode.py
+    scaling: TESTFILE=test_scaling.py
 commands_pre =
     poetry install --only integration
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -67,12 +67,13 @@ commands =
                  {[vars]tests_path}/unit
     poetry run coverage report
 
-[testenv:integration-{charm,multinode,scaling}]
+[testenv:integration-{charm,config,multinode,scaling}]
 description = Run integration tests
 pass_env =
     CI
 set_env =
     charm: TESTFILE=test_charm.py
+    config: TESTFILE=test_config.py
     multinode: TESTFILE=test_multinode.py
     scaling: TESTFILE=test_scaling.py
 commands_pre =


### PR DESCRIPTION
Also resolves [DPE-7515](https://warthogs.atlassian.net/browse/DPE-7515?atlOrigin=eyJpIjoiNWM0ZTVmYWM0NTkxNGE2YWFjOWRmMzEyM2NkYmYxZTUiLCJwIjoiaiJ9) & [DPE-7601](https://warthogs.atlassian.net/browse/DPE-7601?atlOrigin=eyJpIjoiYTJiMzgyYmRlY2M4NDlhMDk1MGRlZjBjZjU5OGY4ZTAiLCJwIjoiaiJ9) & [DPE-7639](https://warthogs.atlassian.net/browse/DPE-7639?atlOrigin=eyJpIjoiYjgwMmRmNGJkNTE4NDkxM2EzYWRkYmJiMTE2ZDBjZTYiLCJwIjoiaiJ9).

This PR:
1. fixes deprecation warnings from the CQL client;
2. adds type hints to several previously raw unit & cluster context fields;
3. adds new status - `waiting for cluster to start`, when non-leader units are waiting for leader unit to initialize cluster;
4. adds `seeds` field in cluster context in order for leader unit to share its peer address (leader = seed until seed management is established);
5. added read/write test into `integration-charm`;
6. added `integration-multinode` & `integration-scaling` & `integration-config` tests;
7. changes `self.workload.restart()` to `self.workload.start()` in `on.start` event;
8. add `collect_app_status` handler, that sets the application status to blocked on invalid config;
9. removes `collect_status` handlers from `charm.py` due to https://github.com/canonical/cassandra-operator/pull/4#discussion_r2169496514;
10. adds docstrings documentation.

@marcoppenheimer 

[DPE-7515]: https://warthogs.atlassian.net/browse/DPE-7515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-7601]: https://warthogs.atlassian.net/browse/DPE-7601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-7639]: https://warthogs.atlassian.net/browse/DPE-7639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ