### PR TITLE
[DPE-7513] Add pyright on tox lint check

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -675,7 +675,7 @@ version = "1.2.18"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-groups = ["main"]
+groups = ["main", "charm-libs"]
 files = [
     {file = "Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec"},
     {file = "deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d"},
@@ -785,7 +785,7 @@ version = "8.6.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "charm-libs"]
 files = [
     {file = "importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e"},
     {file = "importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580"},
@@ -955,7 +955,7 @@ version = "1.32.1"
 description = "OpenTelemetry Python API"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "charm-libs"]
 files = [
     {file = "opentelemetry_api-1.32.1-py3-none-any.whl", hash = "sha256:bbd19f14ab9f15f0e85e43e6a958aa4cb1f36870ee62b7fd205783a112012724"},
     {file = "opentelemetry_api-1.32.1.tar.gz", hash = "sha256:a5be71591694a4d9195caf6776b055aa702e964d961051a0715d05f8632c32fb"},
@@ -971,7 +971,7 @@ version = "2.21.1"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "charm-libs"]
 files = [
     {file = "ops-2.21.1-py3-none-any.whl", hash = "sha256:6745084c8e73bc485c254f95664bd85ddcf786c91b90782f2830c8333a1440b2"},
     {file = "ops-2.21.1.tar.gz", hash = "sha256:4a8190420813ba37e7a0399d656008f99c79015d7f72e138bad7cb1ac403d0b0"},
@@ -1365,7 +1365,7 @@ version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "integration"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
@@ -1671,7 +1671,7 @@ version = "1.8.0"
 description = "WebSocket client for Python with low level API options"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "integration"]
+groups = ["main", "charm-libs", "integration"]
 files = [
     {file = "websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"},
     {file = "websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"},
@@ -1767,7 +1767,7 @@ version = "1.17.2"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "charm-libs"]
 files = [
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984"},
     {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22"},
@@ -1856,7 +1856,7 @@ version = "3.21.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "charm-libs"]
 files = [
     {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
     {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
@@ -1873,4 +1873,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "11571a46fb7c477c14f0b643de2d2e3438393ee8b1da635cc67aa2a9da1b8035"
+content-hash = "d2e9c960530cd9706da4913fc46c034992347b4031cdf5293ad0577f5202cb1a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -921,6 +921,18 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["lint"]
+files = [
+    {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
+    {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1277,6 +1289,27 @@ files = [
 pytz = "*"
 
 [[package]]
+name = "pyright"
+version = "1.1.402"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+groups = ["lint"]
+files = [
+    {file = "pyright-1.1.402-py3-none-any.whl", hash = "sha256:2c721f11869baac1884e846232800fe021c33f1b4acb3929cff321f7ea4e2982"},
+    {file = "pyright-1.1.402.tar.gz", hash = "sha256:85a33c2d40cd4439c66aa946fd4ce71ab2f3f5b8c22ce36a623f59ac22937683"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
+
+[package.extras]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
@@ -1577,7 +1610,7 @@ version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "integration"]
+groups = ["main", "integration", "lint"]
 files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
@@ -1840,4 +1873,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "034d49d65d8c46d80ec45fc529e5b86c56bcd7a4416fd5212e8bf7587f14b0ce"
+content-hash = "11571a46fb7c477c14f0b643de2d2e3438393ee8b1da635cc67aa2a9da1b8035"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ charmlibs-pathops = "^1.0.1"
 [tool.poetry.group.format]
 optional = true
 
+[tool.poetry.group.charm-libs.dependencies]
+# data_platform_libs/v0/data_interfaces.py
+ops = ">=2.0.0"
+
 [tool.poetry.group.format.dependencies]
 ruff = "^0.11.8"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ cassandra-driver = "^3.29.2"
 tenacity = "^9.1.2"
 charmlibs-pathops = "^1.0.1"
 
-[tool.poetry.group.charm-libs.dependencies]
-
 [tool.poetry.group.format]
 optional = true
 
@@ -28,6 +26,7 @@ optional = true
 
 [tool.poetry.group.lint.dependencies]
 codespell = "^2.4.1"
+pyright = "^1.1.402"
 
 [tool.poetry.group.unit]
 optional = true
@@ -95,4 +94,5 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src"]
-extraPaths = ["lib"]
+extraPaths = ["src","lib"]
+pythonVersion = "3.12"

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ allowlist_externals =
     {[testenv]allowlist_externals}
     find
 commands_pre =
-    poetry install --with lint,format
+    poetry install --only lint,main,charm-libs,format
 commands =
     pyright
     poetry check --lock

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
 
 [testenv:lint]
 deps =
-     pyright
+    poetry run pyright
 description = Check code against coding style standards
 allowlist_externals =
     {[testenv]allowlist_externals}

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
 
 [testenv:lint]
 deps =
-    poetry run pyright
+    pyright
 description = Check code against coding style standards
 allowlist_externals =
     {[testenv]allowlist_externals}
@@ -44,7 +44,7 @@ allowlist_externals =
 commands_pre =
     poetry install --only lint,main,charm-libs,format
 commands =
-    pyright
+    poetry run pyright
     poetry check --lock
     poetry run codespell {[vars]all_path}
     poetry run ruff check {[vars]all_path}

--- a/tox.ini
+++ b/tox.ini
@@ -35,13 +35,16 @@ commands =
     poetry run ruff check --fix {[vars]all_path}
 
 [testenv:lint]
+deps =
+     pyright
 description = Check code against coding style standards
 allowlist_externals =
     {[testenv]allowlist_externals}
     find
 commands_pre =
-    poetry install --only lint,format
+    poetry install --with lint,format
 commands =
+    pyright
     poetry check --lock
     poetry run codespell {[vars]all_path}
     poetry run ruff check {[vars]all_path}


### PR DESCRIPTION
As @marcoppenheimer mentioned in [this comment](https://github.com/canonical/cassandra-operator/pull/5#discussion_r2176131995), pyright type checking has now been added to the tox -e lint command.