### PR TITLE
Increase timeout for Free disk space action

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 217  # Sum of steps `timeout-minutes` + 5
     steps:
       - name: Free up disk space
-        timeout-minutes: 1
+        timeout-minutes: 3
         run: |
           printf '\nDisk usage before cleanup\n'
           df --human-readable


### PR DESCRIPTION
# Issue

Sometimes integration tests CI fails due to Free disk space action timeout.
<img width="635" height="674" alt="image" src="https://github.com/user-attachments/assets/8f53a319-1508-4bce-8e7e-0deac39a9258" />


# Fix

This timeout was increased from 1 minute to 3 minutes.