### PR TITLE
Seed node management & Full cluster restart handling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -101,7 +101,6 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
 
     def bootstrap(self, event: RunWithLock) -> None:
         """Start workload and join this unit to the cluster."""
-        # TODO: add leader elected hook
         self.state.unit.workload_state = UnitWorkloadState.STARTING
 
         self.workload.restart()

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -72,9 +72,6 @@ class ClusterState(StrEnum):
 
     UNKNOWN = ""
     """Cassandra cluster isn't yet initialized by the leader unit."""
-    RECOVERING = "recovering"
-    """Leader detected unintended restart of cassandra cluster
-    and waits for all the other units to reset their workload_state."""
     ACTIVE = "active"
     """Cassandra cluster is initialized by the leader unit and active."""
 

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -73,6 +73,8 @@ class ClusterState(StrEnum):
     UNKNOWN = ""
     """Cassandra cluster isn't yet initialized by the leader unit."""
     RECOVERING = "recovering"
+    """Leader detected unintended restart of cassandra cluster
+    and waits for all the other units to reset their workload_state."""
     ACTIVE = "active"
     """Cassandra cluster is initialized by the leader unit and active."""
 

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -72,6 +72,7 @@ class ClusterState(StrEnum):
 
     UNKNOWN = ""
     """Cassandra cluster isn't yet initialized by the leader unit."""
+    RECOVERING = "recovering"
     ACTIVE = "active"
     """Cassandra cluster is initialized by the leader unit and active."""
 

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -299,7 +299,6 @@ class CassandraEvents(Object):
         self._recover_seeds(event)
 
     def _on_update_status(self, _: UpdateStatusEvent) -> None:
-        # TODO: add peer relation change hook for subordinates to update leader address too
         if (
             self._update_network_address()
             and self.state.unit.workload_state == UnitWorkloadState.ACTIVE

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -122,7 +122,7 @@ class CassandraEvents(Object):
         ):
             self.state.cluster.seeds = [self.state.unit.peer_url]
 
-        if not self._check_seeds():
+        if not self._are_seeds_reachable:
             logger.debug("Deferring leader on_start due to seeds not being ready")
             event.defer()
             return
@@ -184,7 +184,7 @@ class CassandraEvents(Object):
             event.defer()
             return
 
-        if not self._check_seeds():
+        if not self._are_seeds_reachable:
             logger.debug("Deferring subordinate on_start due to seeds not being ready")
             event.defer()
             return
@@ -368,7 +368,8 @@ class CassandraEvents(Object):
 
         event.add_status(Status.ACTIVE.value)
 
-    def _check_seeds(self) -> bool:
+    @property
+    def _are_seeds_reachable(self) -> bool:
         return self.state.unit.peer_url in self.state.cluster.seeds or any(
             unit.workload_state == UnitWorkloadState.ACTIVE
             and DatabaseManager(

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -175,7 +175,10 @@ class CassandraEvents(Object):
         self.cluster_manager.prepare_shutdown()
 
     def _start_subordinate(self, event: StartEvent) -> None:
-        if not self.state.cluster.is_active:
+        if (
+            not self.state.cluster.is_active
+            and self.state.unit.peer_url not in self.state.cluster.seeds
+        ):
             self.state.unit.workload_state = UnitWorkloadState.WAITING_FOR_START
             logger.debug("Deferring subordinate on_start due to cluster not being active yet")
             event.defer()

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -300,6 +300,13 @@ class CassandraEvents(Object):
 
     def _on_update_status(self, _: UpdateStatusEvent) -> None:
         if (
+            self.state.unit.workload_state == UnitWorkloadState.ACTIVE
+            and not self.workload.is_alive()
+        ):
+            logger.error("Cassandra service is not alive, but should be. Restarting it")
+            self.workload.restart()
+
+        if (
             self._update_network_address()
             and self.state.unit.workload_state == UnitWorkloadState.ACTIVE
         ):

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -162,7 +162,7 @@ class TLSEvents(Object):
         tls_state.chain = event.chain
 
         if self.charm.unit.is_leader():
-            self.state.cluster.seeds = [self.state.unit.peer_url]
+            self.state.seed_units = self.state.unit
 
         if self.state.unit.workload_state == UnitWorkloadState.ACTIVE:
             self.cluster_manager.prepare_shutdown()
@@ -213,7 +213,7 @@ class TLSEvents(Object):
             state.rotation = True
 
         if self.charm.unit.is_leader():
-            self.state.cluster.seeds = [self.state.unit.peer_url]
+            self.state.seed_units = self.state.unit
 
         if self.state.unit.workload_state == UnitWorkloadState.ACTIVE:
             self.cluster_manager.prepare_shutdown()

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -59,12 +59,13 @@ class TLSEvents(Object):
         self.charm = charm
         self.state = state
         self.workload = workload
+        self.cluster_manager = cluster_manager
         self.config_manager = config_manager
         self.bootstrap_manager = bootstrap_manager
         self.tls_manager = tls_manager
         self.setup_internal_certificates = setup_internal_certificates
 
-        ip, hostname = cluster_manager.network_address()
+        ip, hostname = self.cluster_manager.network_address()
         self.sans = self.tls_manager.build_sans(
             sans_ip=[ip],
             sans_dns=[hostname, self.charm.unit.name],
@@ -160,6 +161,12 @@ class TLSEvents(Object):
         tls_state.ca = event.ca
         tls_state.chain = event.chain
 
+        if self.charm.unit.is_leader():
+            self.state.cluster.seeds = [self.state.unit.peer_url]
+
+        if self.state.unit.workload_state == UnitWorkloadState.ACTIVE:
+            self.cluster_manager.prepare_shutdown()
+
         self.tls_manager.remove_stores(scope=tls_state.scope)
         self.tls_manager.configure(
             tls_state.resolved,
@@ -167,6 +174,7 @@ class TLSEvents(Object):
             trust_password=self.state.unit.truststore_password,
         )
         self.config_manager.render_cassandra_config(
+            seeds=self.state.cluster.seeds,
             enable_peer_tls=self.state.unit.peer_tls.ready,
             enable_client_tls=self.state.unit.client_tls.ready,
             keystore_password=self.state.unit.keystore_password,
@@ -204,7 +212,14 @@ class TLSEvents(Object):
                 return
             state.rotation = True
 
+        if self.charm.unit.is_leader():
+            self.state.cluster.seeds = [self.state.unit.peer_url]
+
+        if self.state.unit.workload_state == UnitWorkloadState.ACTIVE:
+            self.cluster_manager.prepare_shutdown()
+
         self.config_manager.render_cassandra_config(
+            seeds=self.state.cluster.seeds,
             enable_peer_tls=self.state.unit.peer_tls.ready,
             enable_client_tls=self.state.unit.client_tls.ready,
             keystore_password=self.state.unit.keystore_password,

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -38,3 +38,7 @@ class ClusterManager:
     def prepare_shutdown(self) -> None:
         """Prepare Cassandra unit for safe shutdown."""
         self._workload.exec([_NODETOOL, "drain"])
+
+    def decommission(self) -> None:
+        """Disconnect node from the cluster."""
+        self._workload.exec([_NODETOOL, "decommission", "-f"])

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -23,7 +23,7 @@ class ConfigManager:
         workload: WorkloadBase,
         cluster_name: str,
         listen_address: str,
-        seeds: list[str],
+        seeds: set[str],
         enable_peer_tls: bool,
         enable_client_tls: bool,
         keystore_password: str | None,
@@ -44,7 +44,7 @@ class ConfigManager:
         self,
         cluster_name: str | None = None,
         listen_address: str | None = None,
-        seeds: list[str] | None = None,
+        seeds: set[str] | None = None,
         enable_peer_tls: bool | None = None,
         enable_client_tls: bool | None = None,
         keystore_password: str | None = None,
@@ -218,7 +218,7 @@ class ConfigManager:
 
     @staticmethod
     def _cassandra_connectivity_config(
-        cluster_name: str, listen_address: str, seeds: Iterable[str]
+        cluster_name: str, listen_address: str, seeds: set[str]
     ) -> dict[str, Any]:
         return {
             "cluster_name": cluster_name,

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -51,14 +51,19 @@ class DatabaseManager:
         try:
             with self._session() as session:
                 session.execute("SELECT release_version FROM system.local")
+                logger.debug(f"Reachability check success: {','.join(self.hosts)}")
                 return True
         except NoHostAvailable as e:
             if e.errors:
-                for host_error in e.errors.values():
+                for host, host_error in e.errors.items():
                     if isinstance(host_error, AuthenticationFailed):
+                        logger.debug(f"Reachability check success: {host} - {host_error}")
                         return True
+                    else:
+                        logger.debug(f"Reachability check failure: {host} - {host_error}")
             return False
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Reachability check failure: {','.join(self.hosts)} - {e}")
             return False
 
     def init_admin(self, password: str) -> None:

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -41,6 +41,13 @@ class DatabaseManager:
         return
 
     def check(self) -> bool:
+        """Check connectivity to the Cassandra.
+
+        Returns positive even when cluster cannot achieve consistency level for the authentication.
+
+        Returns:
+            whether Cassandra service on this node is ready to accept connections.
+        """
         try:
             with self._session() as session:
                 session.execute("SELECT release_version FROM system.local")
@@ -84,14 +91,6 @@ class DatabaseManager:
             session.execute(
                 "ALTER ROLE %s WITH PASSWORD = %s",
                 [user, password],
-            )
-
-    def update_auth_replication(self, replication_factor: int) -> None:
-        with self._session() as session:
-            session.execute(
-                "ALTER KEYSPACE system_auth"
-                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': %s}",
-                [replication_factor],
             )
 
     @contextmanager

--- a/tests/integration/test_full_cluster_restart.py
+++ b/tests/integration/test_full_cluster_restart.py
@@ -28,7 +28,11 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
 
 def test_lxc_restart(juju: jubilant.Juju) -> None:
     subprocess.check_call(["lxc", "restart", "--all"])
-    juju.wait(jubilant.all_active)
+    juju.wait(
+        ready=lambda status: jubilant.all_agents_idle(status) and jubilant.all_active(status),
+        delay=20,
+        timeout=600,
+    )
 
 
 def test_write(juju: jubilant.Juju, app_name: str) -> None:

--- a/tests/integration/test_full_cluster_restart.py
+++ b/tests/integration/test_full_cluster_restart.py
@@ -19,7 +19,11 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
         config={"profile": "testing"},
         num_units=3,
     )
-    juju.wait(jubilant.all_active)
+    juju.wait(
+        ready=lambda status: jubilant.all_agents_idle(status) and jubilant.all_active(status),
+        delay=20,
+        timeout=1000,
+    )
 
 
 def test_lxc_restart(juju: jubilant.Juju) -> None:

--- a/tests/integration/test_full_cluster_restart.py
+++ b/tests/integration/test_full_cluster_restart.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import subprocess
+from pathlib import Path
+
+import jubilant
+from helpers import connect_cql
+
+logger = logging.getLogger(__name__)
+
+
+def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> None:
+    juju.deploy(
+        cassandra_charm,
+        app=app_name,
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.wait(jubilant.all_active)
+
+
+def test_lxc_restart(juju: jubilant.Juju) -> None:
+    subprocess.check_call(["lxc", "restart", "--all"])
+    juju.wait(jubilant.all_active)
+
+
+def test_write(juju: jubilant.Juju, app_name: str) -> None:
+    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
+    with connect_cql(juju=juju, app_name=app_name, hosts=[host], timeout=300) as session:
+        session.execute(
+            "CREATE KEYSPACE test "
+            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}",
+        )
+        session.set_keyspace("test")
+        session.execute("CREATE TABLE test(message TEXT PRIMARY KEY)")
+        session.execute("INSERT INTO test(message) VALUES ('hello')")

--- a/tests/spread/test_full_cluster_restart.py/task.yaml
+++ b/tests/spread/test_full_cluster_restart.py/task.yaml
@@ -1,5 +1,5 @@
 summary: test_full_cluster_restart.py
 execute: |
-  tox run -e integration-full-cluster-restart -- --alluredir="$SPREAD_TASK/allure-results"
+  tox run -e integration-full-cluster-restart -- --alluredir="$SPREAD_TASK/allure-results" --model-name=test-full-cluster-restart --keep-models
 artifacts:
   - allure-results

--- a/tests/spread/test_full_cluster_restart.py/task.yaml
+++ b/tests/spread/test_full_cluster_restart.py/task.yaml
@@ -1,5 +1,5 @@
 summary: test_full_cluster_restart.py
 execute: |
-  tox run -e integration-full-cluster-restart -- --alluredir="$SPREAD_TASK/allure-results" --model-name=test-full-cluster-restart --keep-models
+  tox run -e integration-full-cluster-restart -- --alluredir="$SPREAD_TASK/allure-results" --model-name=test-cas --keep-models
 artifacts:
   - allure-results

--- a/tests/spread/test_full_cluster_restart.py/task.yaml
+++ b/tests/spread/test_full_cluster_restart.py/task.yaml
@@ -1,0 +1,5 @@
+summary: test_full_cluster_restart.py
+execute: |
+  tox run -e integration-full-cluster-restart -- --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,6 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-from threading import local
 from unittest.mock import PropertyMock, patch
 
 import ops
@@ -12,7 +11,6 @@ from ops import testing
 
 from charm import CassandraCharm
 from core.state import PEER_RELATION
-from managers.cluster import ClusterManager
 
 BOOTSTRAP_RELATION = "bootstrap"
 PEER_SECRET = "cassandra-peers.cassandra.app"

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
                  {[vars]tests_path}/unit
     poetry run coverage report
 
-[testenv:integration-{authentication,charm,config,multinode,scaling,tls,cos}]
+[testenv:integration-{authentication,charm,config,full-cluster-restart,multinode,scaling,tls,cos}]
 description = Run integration tests
 pass_env =
     CI
@@ -75,6 +75,7 @@ set_env =
     authentication: TESTFILE=test_authentication.py
     charm: TESTFILE=test_charm.py
     config: TESTFILE=test_config.py
+    full-cluster-restart: TESTFILE=test_full_cluster_restart.py
     multinode: TESTFILE=test_multinode.py
     scaling: TESTFILE=test_scaling.py
     tls: TESTFILE=test_tls.py


### PR DESCRIPTION
# Overview

This PR is based off [DA213 - Cassandra single seed node management specification](https://docs.google.com/document/d/1saFsnZFViogeyFGG8JFQJAfooxs-tceZo8Estz_WBQQ/edit?usp=sharing), that is currently on-review. It adds new peer changed & leader event handlers and more robust checks in start event handler to ensure cluster successfully recovers itself after full cluster restart or leader change.

# Cassandra seed node <> Juju leader desync

While currently Cassandra operator always configures Juju leader as Cassandra seed node, this PR introduces possibility of seed node setting being assigned to the another unit. It allows cluster to reliably recover from the full cluster restart as seed node will be pointing to knowingly healthy unit. From the future-proof perspective, with the multiple seed node management (that is planned) it will be impossible to hold a sync of seed node with Juju leader, therefore this work is done in the right direction. It also worth mentioning, that the next full cluster config change (TLS change, for example) will again assign seed node to the leader unit to ensure right restart order.