### PR TITLE
[DPE-8066] Adding base documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,92 @@
-# Charmed Apache Cassandra Operator
+This repository contains a charmed operator for deploying [Apache Cassandra](https://cassandra.apache.org/_/cassandra-basics.html) on virtual machines via the [Juju orchestration engine](https://juju.is/).
 
-Apache Cassandra is a free and open-source database management system designed to handle large volumes of data across multiple commodity servers. This charm deploys and operate Apache Cassandra on a VM machine environment.
-Apache Cassandra is a free and open-source software project by the Apache Software Foundation.
-More info can be found at the [Apache Cassandra project page](https://cassandra.apache.org/_/index.html).
 
-## Other resources
+## Overview
 
-- [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
+This operator provides an [Apache Cassandra](https://cassandra.apache.org/) database with support for both single-node and multi-node deployments. It automates the deployment and lifecycle management of Cassandra clusters, ensuring smooth operation from single-node setups to multi-node.
 
-- See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.
+Built as a Juju charm, the operator manages Cassandra on Ubuntu and provides out-of-the-box integrations that make it suitable for enterprise workloads:
+
+* **Scalable deployments**: easily bootstrap single-node or multi-node Cassandra clusters.
+* **Upgrades made safe**: charm refreshes and Cassandra software upgrades with minimal disruption.
+* **Observability by default**: seamless integration with the Canonical Observability Stack (COS) for metrics, logs, and dashboards.
+* **Secure communications**: built-in TLS support for encrypted traffic between nodes.
+* **Authentication**: automatic generation of initial system credentials and secure password rotation with Juju secrets.
+
+## Basic usage
+
+### Deployment
+
+Build a Cassandra charm:
+```shell
+charmcraft pack
+```
+
+Bootstrap a [lxd controller](https://juju.is/docs/olm/lxd#heading--create-a-controller) and create a new Juju model:
+
+```shell
+juju add-model sample-model
+```
+
+
+To deploy a single unit of Cassandra, run the following command:
+
+```shell
+juju deploy cassandra_ubuntu@24.04-amd64.charm cassandra 
+```
+
+Config option `--config profile=testing` can be used for testing purpuses. This will restrict Cassandra node to use minimum memory.
+
+Apache Cassandra is typically deployed as a cluster to provide horizontal scalability and fault tolerance. In Juju, each Cassandra node is represented by a unit.
+
+To start a Cassandra cluster with multiple nodes, set the desired number of units using the `-n` option:
+
+```shell
+juju deploy cassandra_ubuntu@24.04-amd64.charm cassandra -n <number_of_units>
+```
+
+The seed-node is always will be the leader unit in the cluster.
+
+
+### Node management
+
+#### Add node
+
+To add more nodes one can use the `juju add-unit` functionality i.e.
+
+```shell
+juju add-unit cassandra -n <number_of_units_to_add>
+```
+
+The implementation of `add-unit` allows the operator to add more than one unit, at a time. But unit initialization will happen only at one in a time.
+
+#### Remove node
+
+Nodes removal is in progress.
+
+
+### Password rotation
+
+TODO
+
+## Integrations (Relations)
+
+Supported [integrations](https://juju.is/docs/olm/relations):
+
+#### `tls-certificates` interface
+
+TODO
+
+#### `metrics` interface:
+
+TODO
+
+## Contributing
+
+Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/cassandra-operator/blob/main/CONTRIBUTING.md) for developer guidance. 
+
+Also, if you truly enjoy working on open-source projects like this one, check out the [career options](https://canonical.com/careers/all) we have at [Canonical](https://canonical.com/). 
+
+## License
+
+Charmed Apache Cassandra is free software, distributed under the Apache Software License, version 2.0. See [LICENSE](https://github.com/canonical/cassandra-operator/blob/main/LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-This repository contains a charmed operator for deploying [Apache Cassandra](https://cassandra.apache.org/_/cassandra-basics.html) on virtual machines via the [Juju orchestration engine](https://juju.is/).
+# Apache Cassandra Juju Operator
 
+This repository contains a charmed operator for deploying [Apache Cassandra](https://cassandra.apache.org/_/cassandra-basics.html) on virtual machines via the [Juju orchestration engine](https://juju.is/).
 
 ## Overview
 
@@ -18,24 +19,24 @@ Built as a Juju charm, the operator manages Cassandra on Ubuntu and provides out
 ### Deployment
 
 Build a Cassandra charm:
+
 ```shell
 charmcraft pack
 ```
 
-Bootstrap a [lxd controller](https://juju.is/docs/olm/lxd#heading--create-a-controller) and create a new Juju model:
+Bootstrap a [LXD controller](https://juju.is/docs/olm/lxd#heading--create-a-controller) and create a new Juju model:
 
 ```shell
 juju add-model sample-model
 ```
 
-
-To deploy a single unit of Cassandra, run the following command:
+To deploy a single unit of Cassandra:
 
 ```shell
-juju deploy cassandra_ubuntu@24.04-amd64.charm cassandra 
+juju deploy cassandra_ubuntu@24.04-amd64.charm cassandra
 ```
 
-Config option `--config profile=testing` can be used for testing purpuses. This will restrict Cassandra node to use minimum memory.
+The config option `--config profile=testing` can be used for testing purposes. This restricts a Cassandra node to minimum memory usage.
 
 Apache Cassandra is typically deployed as a cluster to provide horizontal scalability and fault tolerance. In Juju, each Cassandra node is represented by a unit.
 
@@ -45,24 +46,23 @@ To start a Cassandra cluster with multiple nodes, set the desired number of unit
 juju deploy cassandra_ubuntu@24.04-amd64.charm cassandra -n <number_of_units>
 ```
 
-The seed-node is always will be the leader unit in the cluster.
-
+The seed node will always be the leader unit in the cluster.
 
 ### Node management
 
-#### Add node
+#### Adding nodes
 
-To add more nodes one can use the `juju add-unit` functionality i.e.
+To add more nodes, use the `juju add-unit` command:
 
 ```shell
 juju add-unit cassandra -n <number_of_units_to_add>
 ```
 
-The implementation of `add-unit` allows the operator to add more than one unit, at a time. But unit initialization will happen only at one in a time.
+The implementation of `add-unit` allows adding multiple units at once, but unit initialization will occur one at a time.
 
-#### Remove node
+#### Removing nodes
 
-Nodes removal is in progress.
+Node removal support is in progress.
 
 ### Connecting
 
@@ -120,24 +120,25 @@ juju show-secret --reveal cassandra-peers.cassandra.app | grep operator
 # operator-password: abcd123456
 ```
 
+> **Note**: Once rotated, all clients must use the new password to connect.
+
 ## Integrations (Relations)
 
 Supported [integrations](https://juju.is/docs/olm/relations):
 
-#### `tls-certificates` interface
+### `tls-certificates` interface
 
 See the [encryption tutorial](docs/how-to/encryption.md) for detailed instructions on adding the `tls-certificates` relation and managing encryption.
 
-#### `metrics` interface
+### `metrics` interface
 
 See the [monitoring tutorial](docs/how-to/monitoring.md) for detailed instructions on adding the `metrics` relation and integrating with the `cos` charm.
 
-
 ## Contributing
 
-Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/cassandra-operator/blob/main/CONTRIBUTING.md) for developer guidance. 
+Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/cassandra-operator/blob/main/CONTRIBUTING.md) for developer guidance.
 
-Also, if you truly enjoy working on open-source projects like this one, check out the [career options](https://canonical.com/careers/all) we have at [Canonical](https://canonical.com/). 
+Also, if you truly enjoy working on open-source projects like this one, check out the [career options](https://canonical.com/careers/all) we have at [Canonical](https://canonical.com/).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This repository contains a charmed operator for deploying [Apache Cassandra](https://cassandra.apache.org/_/cassandra-basics.html) on virtual machines via the [Juju orchestration engine](https://juju.is/).
 
 
-This operator provides an [Apache Cassandra](https://cassandra.apache.org/) database with support for both single-node and multi-node deployments. It automates the deployment and lifecycle management of Cassandra clusters, ensuring smooth operation from single-node setups to multi-node.
+This operator provides an [Apache Cassandra](https://cassandra.apache.org/) database and automates its deployment and lifecycle management, supporting both single-node and multi-node clusters for reliable operation.
 
 Built as a Juju charm, the operator manages Cassandra on Ubuntu and provides out-of-the-box integrations that make it suitable for enterprise workloads:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 This repository contains a charmed operator for deploying [Apache Cassandra](https://cassandra.apache.org/_/cassandra-basics.html) on virtual machines via the [Juju orchestration engine](https://juju.is/).
 
-## Overview
 
 This operator provides an [Apache Cassandra](https://cassandra.apache.org/) database with support for both single-node and multi-node deployments. It automates the deployment and lifecycle management of Cassandra clusters, ensuring smooth operation from single-node setups to multi-node.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ The implementation of `add-unit` allows the operator to add more than one unit, 
 
 Nodes removal is in progress.
 
+### Connecting
+
+Authentication is enabled by default.
+To retrieve the password for the default `operator` user:
+
+```shell
+juju show-secret --reveal "cassandra-peers.<application name>.app" --format json \
+  | jq -r '.[].content.Data."operator-password"'
+```
+
+Once you have the password, connect to the cluster using `cqlsh`:
+
+```shell
+cqlsh <unit-ip> -u operator -p "<password>"
+```
+
+> **Warning**: Supplying a password directly in the command line can be insecure.
+> It is recommended to use a credentials file to provide the password securely.
+
 ## Integrations (Relations)
 
 Supported [integrations](https://juju.is/docs/olm/relations):

--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ cqlsh <unit-ip> -u operator -p "<password>"
 > **Warning**: Supplying a password directly in the command line can be insecure.
 > It is recommended to use a credentials file to provide the password securely.
 
-Отлично 👍 Я сделал секцию **Password rotation** в стиле остальной документации, исправил формулировки и добавил пояснения. Вот итоговый README-фрагмент:
-
----
-
 ## Password rotation
 
 The Cassandra charm supports password rotation for the default `operator` user by leveraging **Juju secrets**.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Supported [integrations](https://juju.is/docs/olm/relations):
 
 See the [encryption tutorial](docs/how-to/encryption.md) for detailed instructions on adding the `tls-certificates` relation and managing encryption.
 
-#### `metrics` interface:
+#### `metrics` interface
 
 TODO
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ Built as a Juju charm, the operator manages Cassandra on Ubuntu and provides out
 * **Secure communications**: built-in TLS support for encrypted traffic between nodes.
 * **Authentication**: automatic generation of initial system credentials and secure password rotation with Juju secrets.
 
+### Prerequisites
+
+Before deploying Cassandra, make sure your environment is ready:
+
+* **Juju** is installed – [installation guide](https://juju.is/docs/olm/get-started-with-juju).
+* **LXD** is installed and initialized – [LXD setup guide](https://juju.is/docs/olm/lxd).
+* **Charmcraft** is installed for building the charm – [installation guide](https://juju.is/docs/sdk/install-charmcraft).
+* A Juju controller is bootstrapped. 
+
+To create a local controller with LXD:
+
+```shell
+juju bootstrap localhost
+```
+
 ### Deployment
 
 Charmed Apache Cassandra is still actively developed and not yet published on Charmhub.io.
@@ -24,7 +39,7 @@ Build a Cassandra charm:
 charmcraft pack
 ```
 
-Bootstrap a [LXD controller](https://juju.is/docs/olm/lxd#heading--create-a-controller) and create a new Juju model:
+Create a new Juju model:
 
 ```shell
 juju add-model sample-model

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ See the [encryption tutorial](docs/how-to/encryption.md) for detailed instructio
 
 #### `metrics` interface
 
-TODO
+See the [monitoring tutorial](docs/how-to/monitoring.md) for detailed instructions on adding the `metrics` relation and integrating with the `cos` charm.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To retrieve the password for the default `operator` user:
 ```shell
 juju show-secret --reveal "cassandra-peers.<application name>.app" --format json \
   | jq -r '.[].content.Data."operator-password"'
-```
+  ```
 
 Once you have the password, connect to the cluster using `cqlsh`:
 
@@ -80,8 +80,22 @@ Once you have the password, connect to the cluster using `cqlsh`:
 cqlsh <unit-ip> -u operator -p "<password>"
 ```
 
-> **Warning**: Supplying a password directly in the command line can be insecure.
-> It is recommended to use a credentials file to provide the password securely.
+Now you can read/write data to Cassandra:
+
+```shell
+Connected to cassandra at 10.166.144.207:9042
+[cqlsh 6.2.0 | Cassandra 5.0.5 | CQL spec 3.4.7 | Native protocol v5]
+Use HELP for help.
+operator@cqlsh> CREATE KEYSPACE hello
+   ... WITH replication = {
+   ...   'class': 'SimpleStrategy',
+   ...   'replication_factor': 1
+   ... };
+operator@cqlsh> DESCRIBE KEYSPACE hello;
+
+CREATE KEYSPACE hello WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
+};
+```
 
 ## Password rotation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Charmed Apache Cassandra
+[![Tests](https://github.com/canonical/cassandra-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/cassandra-operator/actions/workflows/ci.yaml/badge.svg?query=branch%3Amain)
 
 This repository contains a charmed operator for deploying [Apache Cassandra](https://cassandra.apache.org/_/cassandra-basics.html) on virtual machines via the [Juju orchestration engine](https://juju.is/).
 

--- a/README.md
+++ b/README.md
@@ -154,3 +154,5 @@ Also, if you truly enjoy working on open-source projects like this one, check ou
 ## License
 
 Charmed Apache Cassandra is free software, distributed under the Apache Software License, version 2.0. See [LICENSE](https://github.com/canonical/cassandra-operator/blob/main/LICENSE) for more information.
+
+Apache®, Apache Cassandra®, and the Apache Cassandra logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.

--- a/README.md
+++ b/README.md
@@ -142,13 +142,8 @@ juju show-secret --reveal cassandra-peers.cassandra.app | grep operator
 
 Supported [integrations](https://juju.is/docs/olm/relations):
 
-### `tls-certificates` interface
-
-See the [encryption tutorial](docs/how-to/encryption.md) for detailed instructions on adding the `tls-certificates` relation and managing encryption.
-
-### `metrics` interface
-
-See the [monitoring tutorial](docs/how-to/monitoring.md) for detailed instructions on adding the `metrics` relation and integrating with the `cos` charm.
+* `tls-certificates` interface -- See the [encryption tutorial](docs/how-to/encryption.md) for detailed instructions on adding the `tls-certificates` relation and managing encryption.
+* `metrics` interface -- See the [monitoring tutorial](docs/how-to/monitoring.md) for detailed instructions on adding the `metrics` relation and integrating with the `cos` charm.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Cassandra Juju Operator
+# Charmed Apache Cassandra
 
 This repository contains a charmed operator for deploying [Apache Cassandra](https://cassandra.apache.org/_/cassandra-basics.html) on virtual machines via the [Juju orchestration engine](https://juju.is/).
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,47 @@ cqlsh <unit-ip> -u operator -p "<password>"
 > **Warning**: Supplying a password directly in the command line can be insecure.
 > It is recommended to use a credentials file to provide the password securely.
 
+Отлично 👍 Я сделал секцию **Password rotation** в стиле остальной документации, исправил формулировки и добавил пояснения. Вот итоговый README-фрагмент:
+
+---
+
+## Password rotation
+
+The Cassandra charm supports password rotation for the default `operator` user by leveraging **Juju secrets**.
+
+1. **Check the current password**:
+
+```shell
+juju show-secret --reveal cassandra-peers.cassandra.app | grep operator
+# operator-password: a474ikLqA7KscI49zuH1O03bDTI42yJX
+```
+
+2. **Create a new Juju secret with the updated password**:
+
+```shell
+juju add-secret mypass operator=abcd123456
+# secret:d2te3fe3rarc4b9fuj70
+```
+
+3. **Grant Cassandra access to the new secret**:
+
+```shell
+juju grant-secret mypass cassandra
+```
+
+4. **Update Cassandra to use the new secret**:
+
+```shell
+juju config cassandra system-users=secret:d2te3fe3rarc4b9fuj70
+```
+
+5. **Verify that the password has been rotated**:
+
+```shell
+juju show-secret --reveal cassandra-peers.cassandra.app | grep operator
+# operator-password: abcd123456
+```
+
 ## Integrations (Relations)
 
 Supported [integrations](https://juju.is/docs/olm/relations):

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Supported [integrations](https://juju.is/docs/olm/relations):
 
 #### `tls-certificates` interface
 
-TODO
+See the [encryption tutorial](docs/how-to/encryption.md) for detailed instructions on adding the `tls-certificates` relation and managing encryption.
 
 #### `metrics` interface:
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Built as a Juju charm, the operator manages Cassandra on Ubuntu and provides out
 * **Secure communications**: built-in TLS support for encrypted traffic between nodes.
 * **Authentication**: automatic generation of initial system credentials and secure password rotation with Juju secrets.
 
-## Basic usage
-
 ### Deployment
 
 Charmed Apache Cassandra is still actively developed and not yet published on Charmhub.io.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Built as a Juju charm, the operator manages Cassandra on Ubuntu and provides out
 * **Secure communications**: built-in TLS support for encrypted traffic between nodes.
 * **Authentication**: automatic generation of initial system credentials and secure password rotation with Juju secrets.
 
-### Prerequisites
+## Prerequisites
 
 Before deploying Cassandra, make sure your environment is ready:
 
@@ -29,7 +29,7 @@ To create a local controller with LXD:
 juju bootstrap localhost
 ```
 
-### Deployment
+## Deployment
 
 Charmed Apache Cassandra is still actively developed and not yet published on Charmhub.io.
 The best way to deploy it is to build a charm from source code in this repository.
@@ -63,9 +63,11 @@ juju deploy cassandra_ubuntu@24.04-amd64.charm cassandra -n <number_of_units>
 
 The seed node will always be the leader unit in the cluster.
 
-### Node management
+## Node management
 
-#### Adding nodes
+The charm automates most of the node management operations, ensuring that the cluster topology remains consistent and data is replicated correctly.
+
+### Adding nodes
 
 To add more nodes, use the `juju add-unit` command:
 
@@ -75,7 +77,7 @@ juju add-unit cassandra -n <number_of_units_to_add>
 
 The implementation of `add-unit` allows adding multiple units at once, but unit initialization will occur one at a time.
 
-#### Removing nodes
+### Removing nodes
 
 Node removal support is in progress.
 
@@ -156,7 +158,7 @@ juju show-secret --reveal cassandra-peers.cassandra.app | grep operator
 Supported [integrations](https://juju.is/docs/olm/relations):
 
 * `tls-certificates` interface -- See the [encryption tutorial](docs/how-to/encryption.md) for detailed instructions on adding the `tls-certificates` relation and managing encryption.
-* `metrics` interface -- See the [monitoring tutorial](docs/how-to/monitoring.md) for detailed instructions on adding the `metrics` relation and integrating with the `cos` charm.
+* `metrics` interface -- See the [monitoring tutorial](docs/how-to/monitoring.md) for detailed instructions on adding the `metrics` relation and integrating with the `COS` charm.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To deploy a single unit of Cassandra:
 juju deploy cassandra_ubuntu@24.04-amd64.charm cassandra
 ```
 
-The config option `--config profile=testing` can be used for testing purposes. This restricts a Cassandra node to minimum memory usage.
+Use the `--config profile=testing` option to run a Cassandra node with minimal memory for testing purposes.
 
 Apache Cassandra is typically deployed as a cluster to provide horizontal scalability and fault tolerance. In Juju, each Cassandra node is represented by a unit.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Built as a Juju charm, the operator manages Cassandra on Ubuntu and provides out
 
 ### Deployment
 
+Charmed Apache Cassandra is still actively developed and not yet published on Charmhub.io.
+The best way to deploy it is to build a charm from source code in this repository.
 Build a Cassandra charm:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ The implementation of `add-unit` allows the operator to add more than one unit, 
 
 Nodes removal is in progress.
 
-
-### Password rotation
-
-TODO
-
 ## Integrations (Relations)
 
 Supported [integrations](https://juju.is/docs/olm/relations):

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -6,7 +6,6 @@ All units within a cluster share the same CA certificate file, but each unit has
 This charm implements the **Requirer** side of the [tls-certificates](https://charmhub.io/integrations/tls-certificates) relation. Therefore, any charm implementing the **Provider** side can be used.
 To enable TLS encryption, you must first deploy a TLS certificates Provider charm.
 
----
 
 ## Deploy a TLS Provider Charm
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -1,4 +1,4 @@
-# Managing Encryption
+# Managing encryption
 
 The Apache Cassandra charm has encryption enabled by default.
 All units within a cluster share the same CA certificate file, but each unit has a distinct private key.

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -24,7 +24,7 @@ Configure the CA common name:
 juju config self-signed-certificates ca-common-name="Test CA"
 ```
 
-For an overview of available TLS certificate Provider charms and guidance on choosing the right one for your use case, see the [Security with X.509 certificates](https://charmhub.io/topics/security-with-x-509-certificates) page.
+For an overview of available TLS certificate Provider charms and guidance on choosing the right one for your use case, see [this guide](https://charmhub.io/topics/security-with-x-509-certificates).
 
 ## Relate the charms
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -52,7 +52,7 @@ juju show-secret --reveal "cassandra-peers.<application name>.app" --format json
   | jq -r '.[].content.Data."operator-password"'
 ```
 
-### Verify client tls
+### Verify client TLS
 
 First, attempt to connect **without specifying TLS certificates**:
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -7,7 +7,7 @@ This charm implements the **Requirer** side of the [tls-certificates](https://ch
 To enable TLS encryption, you must first deploy a TLS certificates Provider charm.
 
 
-## Deploy a tls provider charm
+## Deploy a TLS provider charm
 
 For testing purposes, you can use the `self-signed-certificates` charm.
 However, this setup is **not recommended** for production clusters.

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -114,7 +114,7 @@ Connect to Cassandra with:
 cqlsh --ssl --cqlshrc=./cqlshrc
 ```
 
-## Disabling tls
+## Disabling TLS
 
 To disable TLS, remove the relations:
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -7,7 +7,7 @@ This charm implements the **Requirer** side of the [tls-certificates](https://ch
 To enable TLS encryption, you must first deploy a TLS certificates Provider charm.
 
 
-## Deploy a TLS Provider Charm
+## Deploy a tls provider charm
 
 For testing purposes, you can use the `self-signed-certificates` charm.
 However, this setup is **not recommended** for production clusters.
@@ -24,7 +24,7 @@ juju config self-signed-certificates ca-common-name="Test CA"
 
 For an overview of available TLS certificate Provider charms and guidance on choosing the right one for your use case, see [this guide](https://charmhub.io/topics/security-with-x-509-certificates).
 
-## Relate the Charms
+## Relate the charms
 
 To enable **peer-to-peer TLS encryption**, relate Cassandra to the `:peer-certificates` endpoint:
 
@@ -40,7 +40,7 @@ juju relate <tls-certificates>:certificates cassandra:client-certificates
 
 where `<tls-certificates>` is the name of the deployed TLS certificates Provider charm.
 
-## Connect to the Cluster
+## Connect to the cluster
 
 Authentication is enabled by default.
 To retrieve the password for the default `operator` user:
@@ -50,7 +50,7 @@ juju show-secret --reveal "cassandra-peers.<application name>.app" --format json
   | jq -r '.[].content.Data."operator-password"'
 ```
 
-### Verifying Client TLS
+### Verifying client tls
 
 First, attempt to connect **without specifying TLS certificates**:
 
@@ -77,7 +77,7 @@ io.netty.handler.ssl.NotSslRecordException: not an SSL/TLS record
 
 This confirms that Cassandra requires a secure TLS connection.
 
-### Retrieving Client Certificates
+### Retrieving client certificates
 
 Fetch the client private key and signed certificate from a unit:
 
@@ -112,7 +112,7 @@ Connect to Cassandra with:
 cqlsh --ssl --cqlshrc=./cqlshrc
 ```
 
-## Disabling TLS
+## Disabling tls
 
 To disable TLS, remove the relations:
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -24,7 +24,7 @@ Configure the CA common name:
 juju config self-signed-certificates ca-common-name="Test CA"
 ```
 
-For an overview of available TLS certificate Provider charms and guidance on choosing the right one for your use case, see [this guide](https://charmhub.io/topics/security-with-x-509-certificates).
+For an overview of available TLS certificate Provider charms and guidance on choosing the right one for your use case, see the [Security with X.509 certificates](https://charmhub.io/topics/security-with-x-509-certificates) page.
 
 ## Relate the charms
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -135,7 +135,3 @@ juju remove-relation <tls-certificates>:certificates cassandra:client-certificat
 ```
 
 where `<tls-certificates>` is the name of the TLS certificates Provider charm deployed.
-
----
-
-Would you like me to also make this more **concise and step-oriented** (like an official operator how-to), or keep the explanatory style?

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -25,8 +25,6 @@ juju config self-signed-certificates ca-common-name="Test CA"
 
 For an overview of available TLS certificate Provider charms and guidance on choosing the right one for your use case, see [this guide](https://charmhub.io/topics/security-with-x-509-certificates).
 
----
-
 ## Relate the Charms
 
 To enable **peer-to-peer TLS encryption**, relate Cassandra to the `:peer-certificates` endpoint:
@@ -43,8 +41,6 @@ juju relate <tls-certificates>:certificates cassandra:client-certificates
 
 where `<tls-certificates>` is the name of the deployed TLS certificates Provider charm.
 
----
-
 ## Connect to the Cluster
 
 Authentication is enabled by default.
@@ -54,8 +50,6 @@ To retrieve the password for the default `operator` user:
 juju show-secret --reveal "cassandra-peers.<application name>.app" --format json \
   | jq -r '.[].content.Data."operator-password"'
 ```
-
----
 
 ### Verifying Client TLS
 
@@ -84,8 +78,6 @@ io.netty.handler.ssl.NotSslRecordException: not an SSL/TLS record
 
 This confirms that Cassandra requires a secure TLS connection.
 
----
-
 ### Retrieving Client Certificates
 
 Fetch the client private key and signed certificate from a unit:
@@ -94,8 +86,6 @@ Fetch the client private key and signed certificate from a unit:
 juju ssh <unit-name> "cat /var/snap/charmed-cassandra/current/etc/cassandra/tls/client-private.key" > ./client.key
 juju ssh <unit-name> "cat /var/snap/charmed-cassandra/current/etc/cassandra/tls/client-unit.pem" > ./client.pem
 ```
-
----
 
 ### Configuring `cqlsh`
 
@@ -122,8 +112,6 @@ Connect to Cassandra with:
 ```shell
 cqlsh --ssl --cqlshrc=./cqlshrc
 ```
-
----
 
 ## Disabling TLS
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -31,13 +31,13 @@ For an overview of available TLS certificate Provider charms and guidance on cho
 To enable **peer-to-peer TLS encryption**, relate Cassandra to the `:peer-certificates` endpoint:
 
 ```shell
-juju relate <tls-certificates>:certificates cassandra:peer-certificates
+juju integrate <tls-certificates>:certificates cassandra:peer-certificates
 ```
 
 To enable **client-to-node TLS encryption**, relate Cassandra to the `:client-certificates` endpoint:
 
 ```shell
-juju relate <tls-certificates>:certificates cassandra:client-certificates
+juju integrate <tls-certificates>:certificates cassandra:client-certificates
 ```
 
 where `<tls-certificates>` is the name of the deployed TLS certificates Provider charm.
@@ -52,7 +52,7 @@ juju show-secret --reveal "cassandra-peers.<application name>.app" --format json
   | jq -r '.[].content.Data."operator-password"'
 ```
 
-### Verifying client tls
+### Verify client tls
 
 First, attempt to connect **without specifying TLS certificates**:
 

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -3,7 +3,7 @@
 The Apache Cassandra charm has encryption enabled by default.
 All units within a cluster share the same CA certificate file, but each unit has a distinct private key.
 
-This charm implements the **Requirer** side of the [`tls-certificates/v1`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/tls_certificates/v1/README.md) relation. Therefore, any charm implementing the **Provider** side can be used.
+This charm implements the **Requirer** side of the [tls-certificates](https://charmhub.io/integrations/tls-certificates) relation. Therefore, any charm implementing the **Provider** side can be used.
 To enable TLS encryption, you must first deploy a TLS certificates Provider charm.
 
 ---

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -1,0 +1,141 @@
+# Managing Encryption
+
+The Apache Cassandra charm has encryption enabled by default.
+All units within a cluster share the same CA certificate file, but each unit has a distinct private key.
+
+This charm implements the **Requirer** side of the [`tls-certificates/v1`](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/tls_certificates/v1/README.md) relation. Therefore, any charm implementing the **Provider** side can be used.
+To enable TLS encryption, you must first deploy a TLS certificates Provider charm.
+
+---
+
+## Deploy a TLS Provider Charm
+
+For testing purposes, you can use the `self-signed-certificates` charm.
+However, this setup is **not recommended** for production clusters.
+
+Deploy the `self-signed-certificates` charm with:
+
+```shell
+# Deploy the TLS charm
+juju deploy self-signed-certificates --channel=edge
+
+# Configure the CA common name
+juju config self-signed-certificates ca-common-name="Test CA"
+```
+
+For an overview of available TLS certificate Provider charms and guidance on choosing the right one for your use case, see [this guide](https://charmhub.io/topics/security-with-x-509-certificates).
+
+---
+
+## Relate the Charms
+
+To enable **peer-to-peer TLS encryption**, relate Cassandra to the `:peer-certificates` endpoint:
+
+```shell
+juju relate <tls-certificates>:certificates cassandra:peer-certificates
+```
+
+To enable **client-to-node TLS encryption**, relate Cassandra to the `:client-certificates` endpoint:
+
+```shell
+juju relate <tls-certificates>:certificates cassandra:client-certificates
+```
+
+where `<tls-certificates>` is the name of the deployed TLS certificates Provider charm.
+
+---
+
+## Connect to the Cluster
+
+Authentication is enabled by default.
+To retrieve the password for the default `operator` user:
+
+```shell
+juju show-secret --reveal "cassandra-peers.<application name>.app" --format json \
+  | jq -r '.[].content.Data."operator-password"'
+```
+
+---
+
+### Verifying Client TLS
+
+First, attempt to connect **without specifying TLS certificates**:
+
+```shell
+cqlsh <unit-ip> -u operator -p "<password>"
+```
+
+This should result in an error:
+
+```
+Warning: Using a password on the command line interface can be insecure.
+Recommendation: use the credentials file to securely provide the password.
+
+Connection error: ('Unable to connect to any servers',
+  {'10.166.144.168:9042': ConnectionResetError(104, 'Connection reset by peer')})
+```
+
+And in the Cassandra logs you will see:
+
+```
+WARN  [epollEventLoopGroup-5-6] ... SSLException in client networking with peer /10.166.144.168:42604
+io.netty.handler.ssl.NotSslRecordException: not an SSL/TLS record
+```
+
+This confirms that Cassandra requires a secure TLS connection.
+
+---
+
+### Retrieving Client Certificates
+
+Fetch the client private key and signed certificate from a unit:
+
+```shell
+juju ssh <unit-name> "cat /var/snap/charmed-cassandra/current/etc/cassandra/tls/client-private.key" > ./client.key
+juju ssh <unit-name> "cat /var/snap/charmed-cassandra/current/etc/cassandra/tls/client-unit.pem" > ./client.pem
+```
+
+---
+
+### Configuring `cqlsh`
+
+To properly use these files, create a `cqlshrc` configuration file for `cqlsh`:
+
+```ini
+[authentication]
+username = operator
+password = <password>
+
+[connection]
+hostname = <unit-ip>
+port = 9042
+
+[ssl]
+certfile = ./client.pem
+validate = true
+userkey = ./client.key
+usercert = ./client.pem
+```
+
+Connect to Cassandra with:
+
+```shell
+cqlsh --ssl --cqlshrc=./cqlshrc
+```
+
+---
+
+## Disabling TLS
+
+To disable TLS, remove the relations:
+
+```shell
+juju remove-relation <tls-certificates>:certificates cassandra:peer-certificates
+juju remove-relation <tls-certificates>:certificates cassandra:client-certificates
+```
+
+where `<tls-certificates>` is the name of the TLS certificates Provider charm deployed.
+
+---
+
+Would you like me to also make this more **concise and step-oriented** (like an official operator how-to), or keep the explanatory style?

--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -15,10 +15,12 @@ However, this setup is **not recommended** for production clusters.
 Deploy the `self-signed-certificates` charm with:
 
 ```shell
-# Deploy the TLS charm
 juju deploy self-signed-certificates --channel=edge
+```
 
-# Configure the CA common name
+Configure the CA common name:
+
+```shell
 juju config self-signed-certificates ca-common-name="Test CA"
 ```
 

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -14,7 +14,7 @@ Since the Charmed Apache Cassandra is deployed directly on a cloud infrastructur
 The [offers-overlay](https://github.com/canonical/cos-lite-bundle/blob/main/overlays/offers-overlay.yaml)
 can be used, and this step is shown in the COS tutorial.
 
-### Offer interfaces via the COS controller
+### Offer interfaces via the cos controller
 
 Switch to COS K8s environment and offer COS interfaces to be cross-model related with Charmed Apache Kafka VM model:
 
@@ -73,7 +73,7 @@ Wait for all components to settle down on a `active/idle` state on both models, 
 
 After this is complete, the monitoring COS stack should be up and running and ready to be used.
 
-### Connect Grafana web interface
+### Connect grafana web interface
 
 To connect to the Grafana web interface, follow the [Browse dashboards](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s?_ga=2.201254254.1948444620.1704703837-757109492.1701777558#heading--browse-dashboards) section of the MicroK8s "Getting started" guide.
 
@@ -103,7 +103,7 @@ If you want a primer to rule writing, refer to the [Prometheus documentation](ht
 
 Then, push your changes to the remote repository.
 
-### Deploy the COS configuration charm
+### Deploy the cos configuration charm
 
 Deploy the [COS configuration](https://charmhub.io/cos-configuration-k8s) charm in the `<cos-model>` model:
 

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -14,7 +14,7 @@ Since the Charmed Apache Cassandra is deployed directly on a cloud infrastructur
 The [offers-overlay](https://github.com/canonical/cos-lite-bundle/blob/main/overlays/offers-overlay.yaml)
 can be used, and this step is shown in the COS tutorial.
 
-### Offer interfaces via the cos controller
+### Offer interfaces via the COS controller
 
 Switch to COS K8s environment and offer COS interfaces to be cross-model related with Charmed Apache Kafka VM model:
 
@@ -36,7 +36,7 @@ juju switch <machine_controller_name>:<cassandra_model_name>
 juju find-offers <k8s_controller>:
 ```
 
-A similar output should appear, if `k8s` is the K8s controller name and `cos` the model where `cos-lite` has been deployed:
+A similar output should appear, if `k8s` is the K8s controller name and `COS` the model where `cos-lite` has been deployed:
 
 ```shell
 Store      URL                                        Access  Interfaces
@@ -73,7 +73,7 @@ Wait for all components to settle down on a `active/idle` state on both models, 
 
 After this is complete, the monitoring COS stack should be up and running and ready to be used.
 
-### Connect grafana web interface
+### Connect Grafana web interface
 
 To connect to the Grafana web interface, follow the [Browse dashboards](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s?_ga=2.201254254.1948444620.1704703837-757109492.1701777558#heading--browse-dashboards) section of the MicroK8s "Getting started" guide.
 
@@ -103,7 +103,7 @@ If you want a primer to rule writing, refer to the [Prometheus documentation](ht
 
 Then, push your changes to the remote repository.
 
-### Deploy the cos configuration charm
+### Deploy the COS configuration charm
 
 Deploy the [COS configuration](https://charmhub.io/cos-configuration-k8s) charm in the `<cos-model>` model:
 

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -58,7 +58,7 @@ Now, deploy `grafana-agent` (subordinate charm) and relate it with Charmed Apach
 
 ```shell
 juju deploy grafana-agent
-juju relate cassandra:cos-agent grafana-agent
+juju integrate cassandra:cos-agent grafana-agent
 ```
 
 Finally, relate `grafana-agent` with consumed COS offers:

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -64,9 +64,9 @@ juju relate cassandra:cos-agent grafana-agent
 Finally, relate `grafana-agent` with consumed COS offers:
 
 ```shell
-juju relate grafana-agent grafana-dashboards
-juju relate grafana-agent loki-logging
-juju relate grafana-agent prometheus-receive-remote-write
+juju integrate grafana-agent grafana-dashboards
+juju integrate grafana-agent loki-logging
+juju integrate grafana-agent prometheus-receive-remote-write
 ```
 
 Wait for all components to settle down on a `active/idle` state on both models, e.g. `<cassandra_model_name>` and `<cos_model_name>`.


### PR DESCRIPTION
## Description

This PR introduces significant enhancements and new features to the documentation. The changes include adding  documentation to the `README.md` and a new `docs/how-to` section, which covers encryption management.

The updated `README.md` now provides a more detailed overview of the operator's capabilities, including:

* **Deployment**: Instructions for deploying single and multi-node Cassandra clusters.
* **Node management**: Guidance on adding and removing units (nodes) to a cluster.
* **Connecting**: Steps to connect to the cluster using `cqlsh` and retrieve credentials for the default `operator` user.
* **Password rotation**: A new section explaining how to securely rotate passwords using Juju secrets.
* **Integrations**: Information on supported relations, specifically for `tls-certificates` and `metrics`.