### PR TITLE
[DPE-8065] Implement release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
     with:
-      channel: latest/edge
+      channel: 5/edge
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@
 name: Release to Charmhub
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@
 name: Release to Charmhub
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,69 +1,9 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 type: charm
 platforms:
   ubuntu@24.04:amd64:
-
-name: cassandra
-summary: |
-  Charmed Apache Cassandra Operator
-description: |
-  Apache Cassandra is a free and open-source database management system designed to handle large volumes of data across multiple commodity servers. This charm deploys and operate Apache Cassandra on a VM machine environment.
-  Apache Cassandra is a free and open-source software project by the Apache Software Foundation.
-  Users can find out more at the [Apache Cassandra project page](https://cassandra.apache.org/_/index.html).
-
-charm-libs:
-  - lib: operator_libs_linux.snap
-    version: "2"
-  - lib: data_platform_libs.data_models
-    version: "1"
-  - lib: data_platform_libs.data_interfaces
-    version: "0"
-  - lib: rolling_ops.rollingops
-    version: "0"
-  - lib: tls_certificates_interface.tls_certificates
-    version: "4"
-  - lib: grafana_agent.cos_agent
-    version: "0"
-
-config:
-  options:
-    profile:
-      type: string
-      default: production
-      description: |
-        Profile represents the scope of deployment, and used to tune resource allocation.
-        Allowed values are: `production` and `testing`.
-        `production` will tune Cassandra for maximum performance and allocation of half of
-        available RAM on the host, while `testing` will tune for minimal resources footprint.
-    system-users:
-      type: secret
-      default: ""
-      description: |
-        Configure the internal system user password. The password will be auto-generated
-        if this option is not set. This needs to be a Juju Secret URI pointing to an
-        accessible secret that contains the following content: `operator: <password>`.
-
-provides:
-  cos-agent:
-    interface: cos_agent
-    optional: true
-
-peers:
-  cassandra-peers:
-    interface: cassandra_peers
-  bootstrap:
-    interface: rolling_op
-
-requires:
-  client-certificates:
-    interface: tls-certificates
-    limit: 1
-    optional: true
-  peer-certificates:
-    interface: tls-certificates
-    limit: 1
-    optional: true
 
 parts:
   # "poetry-deps" part name is a magic constant

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+options:
+  profile:
+    type: string
+    default: production
+    description: |
+      Profile represents the scope of deployment, and used to tune resource allocation.
+      Allowed values are: `production` and `testing`.
+      `production` will tune Cassandra for maximum performance and allocation of half of
+      available RAM on the host, while `testing` will tune for minimal resources footprint.
+  system-users:
+    type: secret
+    default: ""
+    description: |
+      Configure the internal system user password. The password will be auto-generated
+      if this option is not set. This needs to be a Juju Secret URI pointing to an
+      accessible secret that contains the following content: `operator: <password>`.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: cassandra
+summary: |
+  Charmed Apache Cassandra Operator
+description: |
+  Apache Cassandra is a free and open-source database management system designed to handle large volumes of data across multiple commodity servers. This charm deploys and operate Apache Cassandra on a VM machine environment.
+  Apache Cassandra is a free and open-source software project by the Apache Software Foundation.
+  Users can find out more at the [Apache Cassandra project page](https://cassandra.apache.org/_/index.html).
+
+charm-libs:
+  - lib: operator_libs_linux.snap
+    version: "2"
+  - lib: data_platform_libs.data_models
+    version: "1"
+  - lib: data_platform_libs.data_interfaces
+    version: "0"
+  - lib: rolling_ops.rollingops
+    version: "0"
+  - lib: tls_certificates_interface.tls_certificates
+    version: "4"
+  - lib: grafana_agent.cos_agent
+    version: "0"
+
+provides:
+  cos-agent:
+    interface: cos_agent
+    optional: true
+
+peers:
+  cassandra-peers:
+    interface: cassandra_peers
+  bootstrap:
+    interface: rolling_op
+
+requires:
+  client-certificates:
+    interface: tls-certificates
+    limit: 1
+    optional: true
+  peer-certificates:
+    interface: tls-certificates
+    limit: 1
+    optional: true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -126,5 +126,5 @@ def cassandra_charm() -> Path:
 
 @pytest.fixture(scope="module")
 def app_name() -> str:
-    metadata = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+    metadata = yaml.safe_load(Path("./metadata.yaml").read_text())
     return metadata["name"]


### PR DESCRIPTION
Quick changes for making sure to release to the `5/track`. I have already requested the TGR to be created for cassandra on major tracks (see the request [here](https://discourse.charmhub.io/t/adding-data-platform-as-collaborator-for-cassandra-charm/18833)) and used our permission to:

1. Create a `5/track`, see 
```
curl https://api.charmhub.io/v1/charm/cassandra -H'Content-type: application/json' -H "$CHARMHUB_MACAROON_HEADER" 
{"metadata":{"authority":null,"contact":null,"default-track":"latest","description":"Cassandra is a distributed (peer-to-peer) system for the management and\nstorage of structured data.\n","id":"nwYyQPOuk1TkBzmKxWObtvzygxT4YXWh","links":{"contact":[],"issues":["https://bugs.launchpad.net/cassandra-charm"],"website":["https://launchpad.net/cassandra-charm"]},"media":[{"type":"icon","url":"https://api.charmhub.io/api/v1/media/download/charm_nwYyQPOuk1TkBzmKxWObtvzygxT4YXWh_icon_737a810ab4f3b82b805cce1190e3495ef08c4bc457f7c8b52ff1c54055638927.png"}],"name":"cassandra","private":false,"publisher":{"display-name":"Canonical Data Platform","id":"Gu6DrslpIk24NNY2e0qfYx45xrrFhjwl","username":"dataplatformbot","validation":"unproven"},"status":"published","store":"ubuntu","summary":"distributed storage system for structured data","title":null,"track-guardrails":[{"created-at":"2025-09-22T10:08:08.862563","pattern":"\\d+"}],"tracks":[{"automatic-phasing-percentage":null,"created-at":"2025-09-22T11:37:20.509128","name":"5","version-pattern":null},{"automatic-phasing-percentage":null,"created-at":"2025-09-17T05:38:07.854165","name":"latest","version-pattern":null}],"type":"charm","website":"https://launchpad.net/cassandra-charm"}}
``` 

2. Export a token (with permission confined to the `5/` track) and add this in the current repo