### PR TITLE
[DPE-8393] | Scaling down one unit

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -66,9 +66,11 @@ requires:
     optional: true
 
 storage:
-  cassandra:
+  data:
     type: filesystem
-    location: /var/snap/charmed-cassandra/common
+    location: /var/snap/charmed-cassandra/common/var/lib/cassandra
+    minimum-size: 1G
+    description: storage for cassandra data    
 
 parts:
   # "poetry-deps" part name is a magic constant

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -65,6 +65,11 @@ requires:
     limit: 1
     optional: true
 
+storage:
+  cassandra:
+    type: filesystem
+    location: /var/snap/charmed-cassandra/common
+
 parts:
   # "poetry-deps" part name is a magic constant
   # https://github.com/canonical/craft-parts/pull/901

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -16,7 +16,7 @@ r"""Library to manage the relation for the data-platform products.
 
 This library contains the Requires and Provides classes for handling the relation
 between an application and multiple managed application supported by the data-team:
-MySQL, Postgresql, MongoDB, Redis, and Kafka.
+MySQL, Postgresql, MongoDB, Redis, Kafka, and Karapace.
 
 ### Database (MySQL, Postgresql, MongoDB, and Redis)
 
@@ -306,6 +306,105 @@ the situation when an application charm requests a new topic to be created.
 It is preferred to subscribe to this event instead of relation changed event to avoid
 creating a new topic when other information other than a topic name is
 exchanged in the relation databag.
+
+### Karapace
+
+This library is the interface to use and interact with the Karapace charm. This library contains
+custom events that add convenience to manage Karapace, and provides methods to consume the
+application related data.
+
+#### Requirer Charm
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    EndpointsChangedEvent,
+    KarapaceRequires,
+    SubjectAllowedEvent,
+)
+
+class ApplicationCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.karapace = KarapaceRequires(self, relation_name="karapace_client", subject="test-subject")
+        self.framework.observe(
+            self.karapace.on.server_changed, self._on_karapace_server_changed
+        )
+        self.framework.observe(
+            self.karapace.on.subject_allowed, self._on_karapace_subject_allowed
+        )
+        self.framework.observe(
+            self.karapace.on.subject_entity_created, self._on_subject_entity_created
+        )
+
+
+    def _on_karapace_server_changed(self, event: EndpointsChangedEvent):
+        # Event triggered when a server endpoint was changed for this application
+        new_server = event.endpoints
+        ...
+
+    def _on_karapace_subject_allowed(self, event: SubjectAllowedEvent):
+        # Event triggered when a subject was allowed for this application
+        username = event.username
+        password = event.password
+        tls = event.tls
+        endpoints = event.endpoints
+        ...
+
+    def _on_subject_entity_created(self, event: SubjectEntityCreatedEvent):
+        # Event triggered when a subject entity was created this application
+        entity_name = event.entity_name
+        entity_password = event.entity_password
+        ...
+```
+
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+- subject_allowed: event emitted when the requested subject is allowed.
+- server_changed: event emitted when the server endpoints have changed.
+
+#### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+class SampleCharm(CharmBase):
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    KarapaceProvides,
+    SubjectRequestedEvent,
+)
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Default charm events.
+        self.framework.observe(self.on.start, self._on_start)
+
+        # Charm events defined in the Karapace Provides charm library.
+        self.karapace_provider = KarapaceProvides(self, relation_name="karapace_client")
+        self.framework.observe(self.karapace_provider.on.subject_requested, self._on_subject_requested)
+        # Karapace generic helper
+        self.karapace = KarapaceHelper()
+
+    def _on_subject_requested(self, event: SubjectRequestedEvent):
+        # Handle the on_subject_requested event.
+
+        subject = event.subject
+        relation_id = event.relation.id
+        # set connection info in the databag relation
+        self.karapace_provider.set_endpoint(relation_id, self.karapace.get_endpoint())
+        self.karapace_provider.set_credentials(relation_id, username=username, password=password)
+        self.karapace_provider.set_tls(relation_id, "False")
+```
+
+As shown above, the library provides a custom event (subject_requested) to handle
+the situation when an application charm requests a new subject to be created.
+It is preferred to subscribe to this event instead of relation changed event to avoid
+creating a new subject when other information other than a subject name is
+exchanged in the relation databag.
 """
 
 import copy
@@ -318,6 +417,7 @@ from enum import Enum
 from typing import (
     Callable,
     Dict,
+    Final,
     ItemsView,
     KeysView,
     List,
@@ -348,7 +448,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 50
+LIBPATCH = 54
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -1825,13 +1925,36 @@ class RequirerData(Data):
         additional_secret_fields: Optional[List[str]] = [],
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+        requested_entity_secret: Optional[str] = None,
+        requested_entity_name: Optional[str] = None,
+        requested_entity_password: Optional[str] = None,
     ):
         """Manager of base client relations."""
         super().__init__(model, relation_name)
         self.extra_user_roles = extra_user_roles
         self.extra_group_roles = extra_group_roles
         self.entity_type = entity_type
+        self.entity_permissions = entity_permissions
+        self.requested_entity_secret = requested_entity_secret
+        self.requested_entity_name = requested_entity_name
+        self.requested_entity_password = requested_entity_password
+
+        if (
+            self.requested_entity_secret or self.requested_entity_name
+        ) and not self.secrets_enabled:
+            raise SecretsUnavailableError("Secrets unavailable on current Juju version")
+
+        if self.requested_entity_secret and (
+            self.requested_entity_name or self.requested_entity_password
+        ):
+            raise IllegalOperationError("Unable to use provided and automated entity name secret")
+
+        if self.requested_entity_password and not self.requested_entity_name:
+            raise IllegalOperationError("Unable to set entity password without an entity name")
+
         self._validate_entity_type()
+        self._validate_entity_permissions()
 
         self._remote_secret_fields = list(self.SECRET_FIELDS)
         self._local_secret_fields = [
@@ -1871,6 +1994,21 @@ class RequirerData(Data):
 
         if self.entity_type == ENTITY_GROUP and self.extra_user_roles:
             raise ValueError("Inconsistent entity information. Use extra_group_roles instead")
+
+    def _validate_entity_permissions(self) -> None:
+        """Validates whether the provided entity permissions follow the right JSON format."""
+        if not self.entity_permissions:
+            return
+
+        accepted_keys = {"resource_name", "resource_type", "privileges"}
+
+        try:
+            permissions = json.loads(self.entity_permissions)
+            for permission in permissions:
+                if permission.keys() != accepted_keys:
+                    raise ValueError("Invalid entity permissions format. See accepted keys")
+        except json.decoder.JSONDecodeError:
+            raise ValueError("Invalid entity permissions format. It must be JSON format")
 
     # Public functions
 
@@ -2040,22 +2178,16 @@ class DataPeerData(RequirerData, ProviderData):
         self,
         model,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
-        extra_group_roles: Optional[str] = None,
-        entity_type: Optional[str] = None,
     ):
         RequirerData.__init__(
             self,
-            model,
-            relation_name,
-            extra_user_roles,
-            additional_secret_fields,
-            extra_group_roles,
-            entity_type,
+            model=model,
+            relation_name=relation_name,
+            additional_secret_fields=additional_secret_fields,
         )
         self.secret_field_name = secret_field_name if secret_field_name else self.SECRET_FIELD_NAME
         self.deleted_label = deleted_label
@@ -2572,26 +2704,20 @@ class DataPeer(DataPeerData, DataPeerEventHandlers):
         self,
         charm,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
         unique_key: str = "",
-        extra_group_roles: Optional[str] = None,
-        entity_type: Optional[str] = None,
     ):
         DataPeerData.__init__(
             self,
             charm.model,
             relation_name,
-            extra_user_roles,
             additional_secret_fields,
             additional_secret_group_mapping,
             secret_field_name,
             deleted_label,
-            extra_group_roles,
-            entity_type,
         )
         DataPeerEventHandlers.__init__(self, charm, self, unique_key)
 
@@ -2612,26 +2738,20 @@ class DataPeerUnit(DataPeerUnitData, DataPeerEventHandlers):
         self,
         charm,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
         unique_key: str = "",
-        extra_group_roles: Optional[str] = None,
-        entity_type: Optional[str] = None,
     ):
         DataPeerData.__init__(
             self,
             charm.model,
             relation_name,
-            extra_user_roles,
             additional_secret_fields,
             additional_secret_group_mapping,
             secret_field_name,
             deleted_label,
-            extra_group_roles,
-            entity_type,
         )
         DataPeerEventHandlers.__init__(self, charm, self, unique_key)
 
@@ -2670,26 +2790,20 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
         unit: Unit,
         charm: CharmBase,
         relation_name: str,
-        extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
         additional_secret_group_mapping: Dict[str, str] = {},
         secret_field_name: Optional[str] = None,
         deleted_label: Optional[str] = None,
-        extra_group_roles: Optional[str] = None,
-        entity_type: Optional[str] = None,
     ):
         DataPeerOtherUnitData.__init__(
             self,
             unit,
             charm.model,
             relation_name,
-            extra_user_roles,
             additional_secret_fields,
             additional_secret_group_mapping,
             secret_field_name,
             deleted_label,
-            extra_group_roles,
-            entity_type,
         )
         DataPeerOtherUnitEventHandlers.__init__(self, charm, self)
 
@@ -2758,6 +2872,14 @@ class EntityProvidesEvent(RelationEvent):
             return None
 
         return self.relation.data[self.relation.app].get("entity-type")
+
+    @property
+    def entity_permissions(self) -> Optional[str]:
+        """Returns the entity_permissions that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("entity-permissions")
 
 
 class EntityRequiresEvent(RelationEventWithSecret):
@@ -2891,9 +3013,28 @@ class DatabaseRequestedEvent(DatabaseProvidesEvent):
             == "true"
         )
 
+    @property
+    def requested_entity_secret_content(self) -> Optional[Dict[str, Optional[str]]]:
+        """Returns the content of the requested entity secret."""
+        names = None
+        if secret_uri := self.relation.data.get(self.relation.app, {}).get(
+            "requested-entity-secret"
+        ):
+            secret = self.framework.model.get_secret(id=secret_uri)
+            if content := secret.get_content(refresh=True):
+                if "entity-name" in content:
+                    names = {content["entity-name"]: content.get("password")}
+                else:
+                    logger.warning("Invalid requested-entity-secret: no entity name")
+        return names
+
 
 class DatabaseEntityRequestedEvent(DatabaseProvidesEvent, EntityProvidesEvent):
     """Event emitted when a new entity is requested for use on this relation."""
+
+
+class DatabaseEntityPermissionsChangedEvent(DatabaseProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
 
 
 class DatabaseProvidesEvents(CharmEvents):
@@ -2904,6 +3045,7 @@ class DatabaseProvidesEvents(CharmEvents):
 
     database_requested = EventSource(DatabaseRequestedEvent)
     database_entity_requested = EventSource(DatabaseEntityRequestedEvent)
+    database_entity_permissions_changed = EventSource(DatabaseEntityPermissionsChangedEvent)
 
 
 class DatabaseRequiresEvent(RelationEventWithSecret):
@@ -3165,6 +3307,20 @@ class DatabaseProviderEventHandlers(ProviderEventHandlers):
             # To avoid unnecessary application restarts do not trigger other events.
             return
 
+        # Emit a permissions changed event if the setup key (database name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "database" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "database_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
     def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
         """Event emitted when the secret has changed."""
         pass
@@ -3192,6 +3348,10 @@ class DatabaseRequirerData(RequirerData):
         external_node_connectivity: bool = False,
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+        requested_entity_secret: Optional[str] = None,
+        requested_entity_name: Optional[str] = None,
+        requested_entity_password: Optional[str] = None,
     ):
         """Manager of database client relations."""
         super().__init__(
@@ -3201,6 +3361,10 @@ class DatabaseRequirerData(RequirerData):
             additional_secret_fields,
             extra_group_roles,
             entity_type,
+            entity_permissions,
+            requested_entity_secret,
+            requested_entity_name,
+            requested_entity_password,
         )
         self.database = database_name
         self.relations_aliases = relations_aliases
@@ -3388,12 +3552,45 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
             event_data["extra-group-roles"] = self.relation_data.extra_group_roles
         if self.relation_data.entity_type:
             event_data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            event_data["entity-permissions"] = self.relation_data.entity_permissions
+        if self.relation_data.requested_entity_secret:
+            event_data["requested-entity-secret"] = self.relation_data.requested_entity_secret
+
+        # Create helper secret if needed
+        if (
+            self.relation_data.requested_entity_name
+            and not self.relation_data.requested_entity_secret
+        ):
+            content = {"entity-name": self.relation_data.requested_entity_name}
+            if self.relation_data.requested_entity_password:
+                content["password"] = self.relation_data.requested_entity_password
+            secret = self.charm.app.add_secret(
+                content, label=f"{self.model.uuid}-{event.relation.id}-requested-entity"
+            )
+            secret.grant(event.relation)
+            if not secret.id:
+                raise SecretError("Secret helper missing Id")
+            event_data["requested-entity-secret"] = secret.id
 
         # set external-node-connectivity field
         if self.relation_data.external_node_connectivity:
             event_data["external-node-connectivity"] = "true"
 
         self.relation_data.update_relation_data(event.relation.id, event_data)
+
+    def _clear_helper_secret(self, event: RelationChangedEvent, app_databag: Dict) -> None:
+        """Remove helper secret if set."""
+        if (
+            self.relation_data.local_unit.is_leader()
+            and self.relation_data.requested_entity_name
+            and (secret_uri := app_databag.get("requested-entity-secret"))
+        ):
+            try:
+                secret = self.framework.model.get_secret(id=secret_uri)
+                secret.remove_all_revisions()
+            except ModelError:
+                logger.debug("Unable to remove helper secret")
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the database relation has changed."""
@@ -3431,6 +3628,7 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "database_created")
+            self._clear_helper_secret(event, app_databag)
 
             # To avoid unnecessary application restarts do not trigger other events.
             return
@@ -3444,6 +3642,7 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "database_entity_created")
+            self._clear_helper_secret(event, app_databag)
 
             # To avoid unnecessary application restarts do not trigger other events.
             return
@@ -3490,6 +3689,10 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
         external_node_connectivity: bool = False,
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+        requested_entity_secret: Optional[str] = None,
+        requested_entity_name: Optional[str] = None,
+        requested_entity_password: Optional[str] = None,
     ):
         DatabaseRequirerData.__init__(
             self,
@@ -3502,6 +3705,10 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
             external_node_connectivity,
             extra_group_roles,
             entity_type,
+            entity_permissions,
+            requested_entity_secret,
+            requested_entity_name,
+            requested_entity_password,
         )
         DatabaseRequirerEventHandlers.__init__(self, charm, self)
 
@@ -3583,6 +3790,10 @@ class TopicEntityRequestedEvent(KafkaProvidesEvent, EntityProvidesEvent):
     """Event emitted when a new entity is requested for use on this relation."""
 
 
+class TopicEntityPermissionsChangedEvent(KafkaProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
+
+
 class KafkaProvidesEvents(CharmEvents):
     """Kafka events.
 
@@ -3591,6 +3802,7 @@ class KafkaProvidesEvents(CharmEvents):
 
     topic_requested = EventSource(TopicRequestedEvent)
     topic_entity_requested = EventSource(TopicEntityRequestedEvent)
+    topic_entity_permissions_changed = EventSource(TopicEntityPermissionsChangedEvent)
     mtls_cert_updated = EventSource(KafkaClientMtlsCertUpdatedEvent)
 
 
@@ -3751,6 +3963,20 @@ class KafkaProviderEventHandlers(ProviderEventHandlers):
             # To avoid unnecessary application restarts do not trigger other events.
             return
 
+        # Emit a permissions changed event if the setup key (topic name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "topic" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "topic_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
     def _on_secret_changed_event(self, event: SecretChangedEvent):
         """Event notifying about a new value of a secret."""
         if not event.secret.label:
@@ -3801,6 +4027,7 @@ class KafkaRequirerData(RequirerData):
         mtls_cert: Optional[str] = None,
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         """Manager of Kafka client relations."""
         super().__init__(
@@ -3810,6 +4037,7 @@ class KafkaRequirerData(RequirerData):
             additional_secret_fields,
             extra_group_roles,
             entity_type,
+            entity_permissions,
         )
         self.topic = topic
         self.consumer_group_prefix = consumer_group_prefix or ""
@@ -3873,6 +4101,8 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
             relation_data["extra-group-roles"] = self.relation_data.extra_group_roles
         if self.relation_data.entity_type:
             relation_data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            relation_data["entity-permissions"] = self.relation_data.entity_permissions
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
 
@@ -3941,6 +4171,7 @@ class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
         mtls_cert: Optional[str] = None,
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ) -> None:
         KafkaRequirerData.__init__(
             self,
@@ -3953,8 +4184,557 @@ class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
             mtls_cert=mtls_cert,
             extra_group_roles=extra_group_roles,
             entity_type=entity_type,
+            entity_permissions=entity_permissions,
         )
         KafkaRequirerEventHandlers.__init__(self, charm, self)
+
+
+# Karapace related events
+
+
+class KarapaceProvidesEvent(RelationEvent):
+    """Base class for Karapace events."""
+
+    @property
+    def subject(self) -> Optional[str]:
+        """Returns the subject that was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("subject")
+
+
+class SubjectRequestedEvent(KarapaceProvidesEvent):
+    """Event emitted when a new subject is requested for use on this relation."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class SubjectEntityRequestedEvent(KarapaceProvidesEvent, EntityProvidesEvent):
+    """Event emitted when a new entity is requested for use on this relation."""
+
+
+class SubjectEntityPermissionsChangedEvent(KarapaceProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
+
+
+class KarapaceProvidesEvents(CharmEvents):
+    """Karapace events.
+
+    This class defines the events that the Karapace can emit.
+    """
+
+    subject_requested = EventSource(SubjectRequestedEvent)
+    subject_entity_requested = EventSource(SubjectEntityRequestedEvent)
+    subject_entity_permissions_changed = EventSource(SubjectEntityPermissionsChangedEvent)
+
+
+class KarapaceRequiresEvent(RelationEvent):
+    """Base class for Karapace events."""
+
+    @property
+    def subject(self) -> Optional[str]:
+        """Returns the subject."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("subject")
+
+    @property
+    def endpoints(self) -> Optional[str]:
+        """Returns a comma-separated list of broker uris."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("endpoints")
+
+
+class SubjectAllowedEvent(AuthenticationEvent, KarapaceRequiresEvent):
+    """Event emitted when a new subject ACL is created for use on this relation."""
+
+
+class SubjectEntityCreatedEvent(EntityRequiresEvent, KarapaceRequiresEvent):
+    """Event emitted when a new entity is created for use on this relation."""
+
+
+class EndpointsChangedEvent(AuthenticationEvent, KarapaceRequiresEvent):
+    """Event emitted when the endpoints are changed."""
+
+
+class KarapaceRequiresEvents(CharmEvents):
+    """Karapace events.
+
+    This class defines the events that Karapace can emit.
+    """
+
+    subject_allowed = EventSource(SubjectAllowedEvent)
+    subject_entity_created = EventSource(SubjectEntityCreatedEvent)
+    server_changed = EventSource(EndpointsChangedEvent)
+
+
+# Karapace Provides and Requires
+
+
+class KarapaceProviderData(ProviderData):
+    """Provider-side of the Karapace relation."""
+
+    RESOURCE_FIELD = "subject"
+
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
+
+    def set_subject(self, relation_id: int, subject: str) -> None:
+        """Set subject name in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            subject: the subject name.
+        """
+        self.update_relation_data(relation_id, {"subject": subject})
+
+    def set_endpoint(self, relation_id: int, endpoint: str) -> None:
+        """Set the endpoint in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            endpoint: the server address.
+        """
+        self.update_relation_data(relation_id, {"endpoints": endpoint})
+
+
+class KarapaceProviderEventHandlers(ProviderEventHandlers):
+    """Provider-side of the Karapace relation."""
+
+    on = KarapaceProvidesEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KarapaceProviderData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        super()._on_relation_changed_event(event)
+
+        # Leader only
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Validate entity information is not dynamically changed
+        self._validate_entity_consistency(event, diff)
+
+        # Emit a subject requested event if the setup key (subject name)
+        # was added to the relation databag, but the entity-type key was not.
+        if "subject" in diff.added and "entity-type" not in diff.added:
+            getattr(self.on, "subject_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an entity requested event if the setup key (subject name)
+        # was added to the relation databag, in addition to the entity-type key.
+        if "subject" in diff.added and "entity-type" in diff.added:
+            getattr(self.on, "subject_entity_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit a permissions changed event if the setup key (subject name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "subject" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "subject_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        pass
+
+
+class KarapaceProvides(KarapaceProviderData, KarapaceProviderEventHandlers):
+    """Provider-side of the Karapace relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        KarapaceProviderData.__init__(self, charm.model, relation_name)
+        KarapaceProviderEventHandlers.__init__(self, charm, self)
+
+
+class KarapaceRequirerData(RequirerData):
+    """Requirer-side of the Karapace relation."""
+
+    def __init__(
+        self,
+        model: Model,
+        relation_name: str,
+        subject: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+    ):
+        """Manager of Karapace client relations."""
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
+        self.subject = subject
+
+    @property
+    def subject(self):
+        """Topic to use in Karapace."""
+        return self._subject
+
+    @subject.setter
+    def subject(self, value):
+        # Avoid wildcards
+        if value == "*":
+            raise ValueError(f"Error on subject '{value}', cannot be a wildcard.")
+        self._subject = value
+
+
+class KarapaceRequirerEventHandlers(RequirerEventHandlers):
+    """Requires-side of the Karapace relation."""
+
+    on = KarapaceRequiresEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KarapaceRequirerData) -> None:
+        super().__init__(charm, relation_data)
+        # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
+        self.relation_data = relation_data
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the Karapace relation is created."""
+        super()._on_relation_created_event(event)
+
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        # Sets subject and extra user roles
+        relation_data = {"subject": self.relation_data.subject}
+
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+        if self.relation_data.extra_group_roles:
+            relation_data["extra-group-roles"] = self.relation_data.extra_group_roles
+        if self.relation_data.entity_type:
+            relation_data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            relation_data["entity-permissions"] = self.relation_data.entity_permissions
+
+        self.relation_data.update_relation_data(event.relation.id, relation_data)
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        pass
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the Karapace relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the subject ACLs are created
+        # (the Karapace charm shared the credentials).
+
+        # Register all new secrets with their labels
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
+
+        app_databag = get_encoded_dict(event.relation, event.app, "data")
+        if app_databag is None:
+            app_databag = {}
+
+        if self._main_credentials_shared(diff) and "entity-type" not in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("subject ACL created at %s", datetime.now())
+            getattr(self.on, "subject_allowed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        if self._entity_credentials_shared(diff) and "entity-type" in app_databag:
+            # Emit the default event (the one without an alias).
+            logger.info("entity created at %s", datetime.now())
+            getattr(self.on, "subject_entity_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+        # Emit an endpoints changed event if the Karapace endpoints added or changed
+        # this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            getattr(self.on, "server_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )  # here check if this is the right design
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
+
+class KarapaceRequires(KarapaceRequirerData, KarapaceRequirerEventHandlers):
+    """Provider-side of the Karapace relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        subject: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+        extra_group_roles: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
+    ) -> None:
+        KarapaceRequirerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            subject,
+            extra_user_roles,
+            additional_secret_fields,
+            extra_group_roles,
+            entity_type,
+            entity_permissions,
+        )
+        KarapaceRequirerEventHandlers.__init__(self, charm, self)
+
+
+# Kafka Connect Events
+
+
+class KafkaConnectProvidesEvent(RelationEvent):
+    """Base class for Kafka Connect Provider events."""
+
+    @property
+    def plugin_url(self) -> Optional[str]:
+        """Returns the REST endpoint URL which serves the connector plugin."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("plugin-url")
+
+
+class IntegrationRequestedEvent(KafkaConnectProvidesEvent):
+    """Event emitted when a new integrator boots up and is ready to serve the connector plugin."""
+
+
+class KafkaConnectProvidesEvents(CharmEvents):
+    """Kafka Connect Provider Events."""
+
+    integration_requested = EventSource(IntegrationRequestedEvent)
+
+
+class KafkaConnectRequiresEvent(AuthenticationEvent):
+    """Base class for Kafka Connect Requirer events."""
+
+    @property
+    def plugin_url(self) -> Optional[str]:
+        """Returns the REST endpoint URL which serves the connector plugin."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("plugin-url")
+
+
+class IntegrationCreatedEvent(KafkaConnectRequiresEvent):
+    """Event emitted when the credentials are created for this integrator."""
+
+
+class IntegrationEndpointsChangedEvent(KafkaConnectRequiresEvent):
+    """Event emitted when Kafka Connect REST endpoints change."""
+
+
+class KafkaConnectRequiresEvents(CharmEvents):
+    """Kafka Connect Requirer Events."""
+
+    integration_created = EventSource(IntegrationCreatedEvent)
+    integration_endpoints_changed = EventSource(IntegrationEndpointsChangedEvent)
+
+
+class KafkaConnectProviderData(ProviderData):
+    """Provider-side of the Kafka Connect relation."""
+
+    RESOURCE_FIELD = "plugin-url"
+
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
+
+    def set_endpoints(self, relation_id: int, endpoints: str) -> None:
+        """Sets REST endpoints of the Kafka Connect service."""
+        self.update_relation_data(relation_id, {"endpoints": endpoints})
+
+
+class KafkaConnectProviderEventHandlers(EventHandlers):
+    """Provider-side implementation of the Kafka Connect event handlers."""
+
+    on = KafkaConnectProvidesEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KafkaConnectProviderData) -> None:
+        super().__init__(charm, relation_data)
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Leader only
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        if "plugin-url" in diff.added:
+            getattr(self.on, "integration_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        pass
+
+
+class KafkaConnectProvides(KafkaConnectProviderData, KafkaConnectProviderEventHandlers):
+    """Provider-side implementation of the Kafka Connect relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        KafkaConnectProviderData.__init__(self, charm.model, relation_name)
+        KafkaConnectProviderEventHandlers.__init__(self, charm, self)
+
+
+# Sentinel value passed from Kafka Connect requirer side when it does not need to serve any plugins.
+PLUGIN_URL_NOT_REQUIRED: Final[str] = "NOT-REQUIRED"
+
+
+class KafkaConnectRequirerData(RequirerData):
+    """Requirer-side of the Kafka Connect relation."""
+
+    def __init__(
+        self,
+        model: Model,
+        relation_name: str,
+        plugin_url: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+    ):
+        """Manager of Kafka client relations."""
+        super().__init__(
+            model,
+            relation_name,
+            extra_user_roles=extra_user_roles,
+            additional_secret_fields=additional_secret_fields,
+        )
+        self.plugin_url = plugin_url
+
+    @property
+    def plugin_url(self):
+        """The REST endpoint URL which serves the connector plugin."""
+        return self._plugin_url
+
+    @plugin_url.setter
+    def plugin_url(self, value):
+        self._plugin_url = value
+
+
+class KafkaConnectRequirerEventHandlers(RequirerEventHandlers):
+    """Requirer-side of the Kafka Connect relation."""
+
+    on = KafkaConnectRequiresEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(self, charm: CharmBase, relation_data: KafkaConnectRequirerData) -> None:
+        super().__init__(charm, relation_data)
+        self.relation_data = relation_data
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the Kafka Connect relation is created."""
+        super()._on_relation_created_event(event)
+
+        if not self.relation_data.local_unit.is_leader():
+            return
+
+        relation_data = {"plugin-url": self.relation_data.plugin_url}
+        self.relation_data.update_relation_data(event.relation.id, relation_data)
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event notifying about a new value of a secret."""
+        pass
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the Kafka Connect relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Register all new secrets with their labels
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
+
+        if self._main_credentials_shared(diff):
+            logger.info("integration created at %s", datetime.now())
+            getattr(self.on, "integration_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+            return
+
+        # Emit an endpoints changed event if the provider added or
+        # changed this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            getattr(self.on, "integration_endpoints_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+            return
+
+
+class KafkaConnectRequires(KafkaConnectRequirerData, KafkaConnectRequirerEventHandlers):
+    """Requirer-side implementation of the Kafka Connect relation."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        plugin_url: str,
+        extra_user_roles: Optional[str] = None,
+        additional_secret_fields: Optional[List[str]] = [],
+    ) -> None:
+        KafkaConnectRequirerData.__init__(
+            self,
+            charm.model,
+            relation_name,
+            plugin_url,
+            extra_user_roles=extra_user_roles,
+            additional_secret_fields=additional_secret_fields,
+        )
+        KafkaConnectRequirerEventHandlers.__init__(self, charm, self)
 
 
 # Opensearch related events
@@ -3988,6 +4768,10 @@ class IndexEntityRequestedEvent(OpenSearchProvidesEvent, EntityProvidesEvent):
     """Event emitted when a new entity is requested for use on this relation."""
 
 
+class IndexEntityPermissionsChangedEvent(OpenSearchProvidesEvent, EntityProvidesEvent):
+    """Event emitted when existing entity permissions are changed on this relation."""
+
+
 class OpenSearchProvidesEvents(CharmEvents):
     """OpenSearch events.
 
@@ -3996,6 +4780,7 @@ class OpenSearchProvidesEvents(CharmEvents):
 
     index_requested = EventSource(IndexRequestedEvent)
     index_entity_requested = EventSource(IndexEntityRequestedEvent)
+    index_entity_permissions_changed = EventSource(IndexEntityPermissionsChangedEvent)
 
 
 class OpenSearchRequiresEvent(DatabaseRequiresEvent):
@@ -4107,6 +4892,20 @@ class OpenSearchProvidesEventHandlers(ProviderEventHandlers):
             # To avoid unnecessary application restarts do not trigger other events.
             return
 
+        # Emit a permissions changed event if the setup key (index name)
+        # was added to the relation databag, and the entity-permissions key changed.
+        if (
+            "index" not in diff.added
+            and "entity-type" not in diff.added
+            and ("entity-permissions" in diff.added or "entity-permissions" in diff.changed)
+        ):
+            getattr(self.on, "index_entity_permissions_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # To avoid unnecessary application restarts do not trigger other events.
+            return
+
     def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
         """Event emitted when the relation data has changed."""
         pass
@@ -4132,6 +4931,7 @@ class OpenSearchRequiresData(RequirerData):
         additional_secret_fields: Optional[List[str]] = [],
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         """Manager of OpenSearch client relations."""
         super().__init__(
@@ -4141,6 +4941,7 @@ class OpenSearchRequiresData(RequirerData):
             additional_secret_fields,
             extra_group_roles,
             entity_type,
+            entity_permissions,
         )
         self.index = index
 
@@ -4172,6 +4973,8 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
             data["extra-group-roles"] = self.relation_data.extra_group_roles
         if self.relation_data.entity_type:
             data["entity-type"] = self.relation_data.entity_type
+        if self.relation_data.entity_permissions:
+            data["entity-permissions"] = self.relation_data.entity_permissions
 
         self.relation_data.update_relation_data(event.relation.id, data)
 
@@ -4270,6 +5073,7 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
         additional_secret_fields: Optional[List[str]] = [],
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ) -> None:
         OpenSearchRequiresData.__init__(
             self,
@@ -4280,6 +5084,7 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
             additional_secret_fields,
             extra_group_roles,
             entity_type,
+            entity_permissions,
         )
         OpenSearchRequiresEventHandlers.__init__(self, charm, self)
 
@@ -4482,6 +5287,7 @@ class EtcdRequirerData(RequirerData):
         additional_secret_fields: Optional[List[str]] = [],
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ):
         """Manager of Etcd client relations."""
         super().__init__(
@@ -4491,6 +5297,7 @@ class EtcdRequirerData(RequirerData):
             additional_secret_fields,
             extra_group_roles,
             entity_type,
+            entity_permissions,
         )
         self.prefix = prefix
         self.mtls_cert = mtls_cert
@@ -4603,6 +5410,7 @@ class EtcdRequires(EtcdRequirerData, EtcdRequirerEventHandlers):
         additional_secret_fields: Optional[List[str]] = [],
         extra_group_roles: Optional[str] = None,
         entity_type: Optional[str] = None,
+        entity_permissions: Optional[str] = None,
     ) -> None:
         EtcdRequirerData.__init__(
             self,
@@ -4614,6 +5422,7 @@ class EtcdRequires(EtcdRequirerData, EtcdRequirerEventHandlers):
             additional_secret_fields,
             extra_group_roles,
             entity_type,
+            entity_permissions,
         )
         EtcdRequirerEventHandlers.__init__(self, charm, self)
         if not self.secrets_enabled:

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -52,7 +52,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -1804,7 +1804,7 @@ class TLSCertificatesProvidesV4(Object):
         self, relation: Relation, unit_or_app: Union[Application, Unit]
     ) -> List[RequirerCertificateRequest]:
         try:
-            requirer_relation_data = _RequirerData.load(relation.data[unit_or_app])
+            requirer_relation_data = _RequirerData.load(relation.data.get(unit_or_app, {}))
         except DataValidationError:
             logger.debug("Invalid requirer relation data for %s", unit_or_app.name)
             return []

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -75,6 +75,7 @@ class ClusterState(StrEnum):
     ACTIVE = "active"
     """Cassandra cluster is initialized by the leader unit and active."""
 
+
 class UnitWorkloadState(StrEnum):
     """Current state of the Cassandra workload."""
 
@@ -86,8 +87,7 @@ class UnitWorkloadState(StrEnum):
     """Cassandra is starting."""
     ACTIVE = "active"
     """Cassandra is active and ready."""
-    DECOMMISSIONING = "decomissioning"
-    """Cassandra is in decommission process."""
+
 
 class RelationState:
     """Basic class for relation bag mapping classes."""

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -75,7 +75,6 @@ class ClusterState(StrEnum):
     ACTIVE = "active"
     """Cassandra cluster is initialized by the leader unit and active."""
 
-
 class UnitWorkloadState(StrEnum):
     """Current state of the Cassandra workload."""
 
@@ -87,7 +86,8 @@ class UnitWorkloadState(StrEnum):
     """Cassandra is starting."""
     ACTIVE = "active"
     """Cassandra is active and ready."""
-
+    DECOMMISSIONING = "decomissioning"
+    """Cassandra is in decommission process."""
 
 class RelationState:
     """Basic class for relation bag mapping classes."""

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -22,6 +22,7 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
 )
 from ops import Application, CharmBase, Object, Relation, Unit
 
+DATA_STORAGE = "data"
 CLIENT_TLS_RELATION = "client-certificates"
 PEER_TLS_RELATION = "peer-certificates"
 PEER_RELATION = "cassandra-peers"

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -34,7 +34,7 @@ from tenacity import (
 from common.exceptions import BadSecretError, ExecError
 from core.config import CharmConfig
 from core.literals import CASSANDRA_ADMIN_USERNAME
-from core.state import PEER_RELATION, ApplicationState, UnitWorkloadState
+from core.state import PEER_RELATION, ApplicationState, UnitWorkloadState, DATA_STORAGE
 from core.statuses import Status
 from core.workload import WorkloadBase
 from managers.cluster import ClusterManager
@@ -88,7 +88,7 @@ class CassandraEvents(Object):
         self.framework.observe(self.charm.on.collect_unit_status, self._on_collect_unit_status)
         self.framework.observe(self.charm.on.collect_app_status, self._on_collect_app_status)
         self.framework.observe(
-            self.charm.on.cassandra_storage_detaching, self._on_storage_detaching
+            self.charm.on[DATA_STORAGE].storage_detaching, self._on_storage_detaching
         )
 
     def _on_install(self, _: InstallEvent) -> None:

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -428,4 +428,4 @@ class CassandraEvents(Object):
             logger.error(f"Failed to decommission unit: {e}")
             raise e
 
-        logger.info("Storage deatached")
+        logger.info("Hook for storage-detaching event completed")

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -420,7 +420,7 @@ class CassandraEvents(Object):
         )
 
     def _on_storage_detaching(self, _: StorageDetachingEvent) -> None:
-        if not self.cluster_manager.cluster_healthy():
+        if not self.node_manager.is_healthy(self.state.unit.ip):
             raise Exception("Cluster is not healthy, cannot remove unit")
 
         if self.charm.app.planned_units() < len(self.state.units) - 1:
@@ -431,7 +431,7 @@ class CassandraEvents(Object):
 
         logger.info(f"Starting unit {self.state.unit.unit_name} node decommissioning")
         try:
-            self.cluster_manager.decommission()
+            self.node_manager.decommission()
         except ExecError as e:
             logger.error(f"Failed to decommission unit: {e}")
             raise e

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -34,7 +34,7 @@ from tenacity import (
 from common.exceptions import BadSecretError, ExecError
 from core.config import CharmConfig
 from core.literals import CASSANDRA_ADMIN_USERNAME
-from core.state import PEER_RELATION, ApplicationState, UnitWorkloadState, DATA_STORAGE
+from core.state import DATA_STORAGE, PEER_RELATION, ApplicationState, UnitWorkloadState
 from core.statuses import Status
 from core.workload import WorkloadBase
 from managers.cluster import ClusterManager

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -9,11 +9,17 @@ import socket
 
 from common.exceptions import ExecError
 from core.workload import WorkloadBase
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
 _NODETOOL = "charmed-cassandra.nodetool"
 
+@dataclass
+class GossipNode:
+    ip: str
+    rpc_ready: str | None = None
+    status_with_port: str | None = None
 
 class ClusterManager:
     """Manager of Cassandra cluster, including this unit."""
@@ -24,6 +30,13 @@ class ClusterManager:
     @property
     def is_healthy(self) -> bool:
         """Whether Cassandra healthy and ready in this unit."""
+        gossip_info = self.get_gossipinfo().get(self.network_address()[0])
+        if not gossip_info:
+            gossip_info = self.get_gossipinfo().get("127.0.0.1")
+
+        if not gossip_info or "NORMAL" not in str(gossip_info.status_with_port):
+            return False
+        
         try:
             stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
             return "Native Transport active: true" in stdout
@@ -31,7 +44,7 @@ class ClusterManager:
             return False
 
     def network_address(self) -> tuple[str, str]:
-        """Get hostname and IP of this unit."""
+        """Get IP and hostname of this unit."""
         hostname = socket.gethostname()
         return socket.gethostbyname(hostname), hostname
 
@@ -42,3 +55,56 @@ class ClusterManager:
     def decommission(self) -> None:
         """Disconnect node from the cluster."""
         self._workload.exec([_NODETOOL, "decommission", "-f"])
+        
+    def cluster_healthy(self) -> bool:
+        gossip = self.get_gossipinfo()
+        if not gossip:
+            return False
+
+        for node in gossip.values():
+            if "NORMAL" not in str(node.status_with_port):
+                return False
+
+        return True
+
+    def get_gossipinfo(self) -> dict[str, GossipNode]:
+        """
+        Get `nodetool gossipinfo` command result in to the dict:
+        { <IP>: GossipNode, ... }
+        """
+
+        try:
+            text, _ = self._workload.exec([_NODETOOL, "gossipinfo"], suppress_error_log=True)
+        except ExecError:
+            return {}
+        
+        
+        result = {}
+        blocks = text.strip().split("\n/")
+        for block in blocks:
+            lines = block.strip().splitlines()
+            if not lines:
+                continue
+            first_line = lines[0].lstrip("/")
+            ip = first_line.split()[0]
+            node_data = {}
+            for line in lines[1:]:
+                if ":" not in line:
+                    continue
+                key, *rest = line.strip().split(":", maxsplit=2)
+                if len(rest) == 1:
+                    value = rest[0]
+                elif len(rest) == 2:
+                    _, value = rest
+                else:
+                    value = ":".join(rest)
+                node_data[key.strip().upper()] = value.strip()
+            
+            node = GossipNode(
+                ip=ip,
+                rpc_ready=node_data.get("RPC_READY"),
+                status_with_port=node_data.get("STATUS_WITH_PORT"),
+            )
+            result[ip] = node
+        return result
+    

--- a/src/managers/node.py
+++ b/src/managers/node.py
@@ -115,18 +115,6 @@ class NodeManager:
 
         return True
         
-    def cluster_healthy(self) -> bool:
-        """Check if all nodes in cluster are Up and Normal."""
-        gossip = self.get_gossipinfo()
-        if not gossip:
-            return False
-
-        for node in gossip.values():
-            if "NORMAL" not in str(node.status_with_port):
-                return False
-
-        return True
-
     def get_gossipinfo(self) -> dict[str, GossipNode]:
         """Get `nodetool gossipinfo` command.
 

--- a/src/managers/node.py
+++ b/src/managers/node.py
@@ -6,10 +6,10 @@
 
 import logging
 import socket
+from dataclasses import dataclass
 
 from common.exceptions import ExecError
 from core.workload import WorkloadBase
-from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ class NodeManager:
             return False
 
         return True
-        
+
     def get_gossipinfo(self) -> dict[str, GossipNode]:
         """Get `nodetool gossipinfo` command.
 
@@ -154,4 +154,3 @@ class NodeManager:
             )
             result[ip] = node
         return result
-

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -3,14 +3,15 @@
 # See LICENSE file for licensing details.
 
 import logging
+from os import write
 from pathlib import Path
 
 import jubilant
 from cassandra.cluster import ResultSet
-from helpers import connect_cql
+from helpers import assert_rows, connect_cql, prepare_keyspace_and_table, read_n_rows, write_n_rows
 
 logger = logging.getLogger(__name__)
-
+TEST_ROW_NUM = 100
 
 def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> None:
     juju.deploy(
@@ -21,50 +22,72 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
     )
     juju.wait(jubilant.all_active)
 
+    
+def test_scale_up(juju: jubilant.Juju, app_name: str) -> None:
+    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="upks",table="uptbl")
 
-def test_write(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], timeout=300) as session:
-        session.execute(
-            "CREATE KEYSPACE test "
-            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}",
-        )
-        session.set_keyspace("test")
-        session.execute("CREATE TABLE test(message TEXT PRIMARY KEY)")
-        session.execute("INSERT INTO test(message) VALUES ('hello')")
-
-
-def test_read(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test", timeout=300)
-        assert (
-            isinstance(res, ResultSet)
-            and len(res_list := res.all()) == 1
-            and res_list[0].message == "hello"
-        ), "test data written prior aren't found"
-
-
-def test_scale(juju: jubilant.Juju, app_name: str) -> None:
+    wrote = write_n_rows(juju, app_name, ks=ks, table=tb)
+    got1 = read_n_rows(juju, app_name, ks=ks, table=tb)
+    assert_rows(wrote, got1)
+    
     juju.add_unit(app_name, num_units=2)
     juju.wait(jubilant.all_active)
 
+    added_units = [u[0] for u in juju.status().apps[app_name].units.items() if not u[1].leader]
 
-def test_write_multinode(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(
-        juju=juju, app_name=app_name, hosts=[host], timeout=300, keyspace="test"
-    ) as session:
-        session.execute("INSERT INTO test(message) VALUES ('world')")
+    got2 = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=added_units[0])
+    assert_rows(wrote, got2)
+    
+def test_read_write_multinode(juju: jubilant.Juju, app_name: str) -> None:
+    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="multiks",table="multitbl")
 
+    added_units = [u[0] for u in juju.status().apps[app_name].units.items() if not u[1].leader]
 
-def test_read_multinode(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/2"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test", timeout=300)
-        assert (
-            isinstance(res, ResultSet)
-            and len(res_list := res.all()) == 2
-            and res_list[0].message == "hello"
-            and res_list[1].message == "world"
-        ), "test data written prior aren't found"
+    assert len(added_units) > 1
+
+    wrote = write_n_rows(juju, app_name, ks=ks, table=tb, unit_name=added_units[0])
+    got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=added_units[1])
+    assert_rows(wrote, got)
+    
+def test_single_node_scale_down(juju: jubilant.Juju, app_name: str) -> None:
+    non_leader_units = [
+        name
+        for name, unit in juju.status().apps[app_name].units.items()
+        if not unit.leader
+    ]
+
+    leader_unit = [
+        name
+        for name, unit in juju.status().apps[app_name].units.items()
+        if unit.leader
+    ][0]
+
+    assert len(non_leader_units) != 0 and len(non_leader_units) > 1
+
+    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="downks",table="downtbl")
+    wrote = write_n_rows(juju, app_name, ks=ks, table=tb, unit_name=non_leader_units[0])
+    
+    juju.remove_unit(non_leader_units[0])
+    juju.wait(jubilant.all_active)
+
+    got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=non_leader_units[1])    
+    assert_rows(wrote, got)    
+
+    juju.remove_unit(leader_unit)
+    juju.wait(jubilant.all_active)
+
+    new_leader_unit = [
+        name
+        for name, unit in juju.status().apps[app_name].units.items()
+        if unit.leader
+    ][0]
+
+    assert new_leader_unit
+    
+    got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=new_leader_unit)    
+    assert_rows(wrote, got)
+    
+
+    
+
+    

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -3,15 +3,14 @@
 # See LICENSE file for licensing details.
 
 import logging
-from os import write
 from pathlib import Path
 
 import jubilant
-from cassandra.cluster import ResultSet
-from helpers import assert_rows, connect_cql, prepare_keyspace_and_table, read_n_rows, write_n_rows
+from helpers import assert_rows, prepare_keyspace_and_table, read_n_rows, write_n_rows
 
 logger = logging.getLogger(__name__)
 TEST_ROW_NUM = 100
+
 
 def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> None:
     juju.deploy(
@@ -22,14 +21,14 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
     )
     juju.wait(jubilant.all_active)
 
-    
+
 def test_scale_up(juju: jubilant.Juju, app_name: str) -> None:
-    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="upks",table="uptbl")
+    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="upks", table="uptbl")
 
     wrote = write_n_rows(juju, app_name, ks=ks, table=tb)
     got1 = read_n_rows(juju, app_name, ks=ks, table=tb)
     assert_rows(wrote, got1)
-    
+
     juju.add_unit(app_name, num_units=2)
     juju.wait(jubilant.all_active)
 
@@ -37,9 +36,10 @@ def test_scale_up(juju: jubilant.Juju, app_name: str) -> None:
 
     got2 = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=added_units[0])
     assert_rows(wrote, got2)
-    
+
+
 def test_read_write_multinode(juju: jubilant.Juju, app_name: str) -> None:
-    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="multiks",table="multitbl")
+    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="multiks", table="multitbl")
 
     added_units = [u[0] for u in juju.status().apps[app_name].units.items() if not u[1].leader]
 
@@ -48,46 +48,36 @@ def test_read_write_multinode(juju: jubilant.Juju, app_name: str) -> None:
     wrote = write_n_rows(juju, app_name, ks=ks, table=tb, unit_name=added_units[0])
     got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=added_units[1])
     assert_rows(wrote, got)
-    
+
+
 def test_single_node_scale_down(juju: jubilant.Juju, app_name: str) -> None:
     non_leader_units = [
-        name
-        for name, unit in juju.status().apps[app_name].units.items()
-        if not unit.leader
+        name for name, unit in juju.status().apps[app_name].units.items() if not unit.leader
     ]
 
     leader_unit = [
-        name
-        for name, unit in juju.status().apps[app_name].units.items()
-        if unit.leader
+        name for name, unit in juju.status().apps[app_name].units.items() if unit.leader
     ][0]
 
     assert len(non_leader_units) != 0 and len(non_leader_units) > 1
 
-    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="downks",table="downtbl")
+    ks, tb = prepare_keyspace_and_table(juju, app_name=app_name, ks="downks", table="downtbl")
     wrote = write_n_rows(juju, app_name, ks=ks, table=tb, unit_name=non_leader_units[0])
-    
+
     juju.remove_unit(non_leader_units[0])
     juju.wait(jubilant.all_active)
 
-    got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=non_leader_units[1])    
-    assert_rows(wrote, got)    
+    got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=non_leader_units[1])
+    assert_rows(wrote, got)
 
     juju.remove_unit(leader_unit)
     juju.wait(jubilant.all_active)
 
     new_leader_unit = [
-        name
-        for name, unit in juju.status().apps[app_name].units.items()
-        if unit.leader
+        name for name, unit in juju.status().apps[app_name].units.items() if unit.leader
     ][0]
 
     assert new_leader_unit
-    
-    got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=new_leader_unit)    
+
+    got = read_n_rows(juju, app_name, ks=ks, table=tb, unit_name=new_leader_unit)
     assert_rows(wrote, got)
-    
-
-    
-
-    

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -46,9 +46,14 @@ def test_scale_up(juju: jubilant.Juju, app_name: str) -> None:
 def test_read_write_multinode(juju: jubilant.Juju, app_name: str) -> None:
     units = juju.status().apps[app_name].units.items()
     for unit_pair in pairwise(units):
-        unit1_name, unit2_name = unit_pair[0][0], unit_pair[1][0]
+        unit1_name: str = unit_pair[0][0]
+        unit2_name: str = unit_pair[1][0]
+
         ks, tb = prepare_keyspace_and_table(
-            juju, app_name=app_name, ks="multiks", table=f"multitbl-{unit1_name}-{unit2_name}"
+            juju,
+            app_name=app_name,
+            ks="multiks",
+            table=f"""multitbl_{unit1_name.replace("/", "_")}_{unit2_name.replace("/", "_")}""",
         )
 
         assert len(unit_pair) > 1

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -32,7 +32,7 @@ def test_storage_detaching_cluster_unhealthy(caplog):
             "managers.tls.TLSManager.client_tls_ready",
             new_callable=PropertyMock(return_value=False),
         ),
-        patch("managers.node.NodeManager.cluster_healthy", return_value=False),
+        patch("managers.node.NodeManager.is_healthy", return_value=False),
         patch("managers.node.NodeManager.decommission") as decommission,
     ):
         workload.return_value.generate_password.return_value = "password"
@@ -54,7 +54,7 @@ def test_storage_detaching_multiple_units_removal_logs_warning(caplog):
             "managers.tls.TLSManager.client_tls_ready",
             new_callable=PropertyMock(return_value=False),
         ),
-        patch("managers.node.NodeManager.cluster_healthy", return_value=True),
+        patch("managers.node.NodeManager.is_healthy", return_value=True),
         patch("managers.node.NodeManager.decommission", return_value=None) as decommission,
         patch("ops.model.Application.planned_units", return_value=1),
         patch(
@@ -83,7 +83,7 @@ def test_storage_detaching_success(caplog):
             "managers.tls.TLSManager.client_tls_ready",
             new_callable=PropertyMock(return_value=False),
         ),
-        patch("managers.node.NodeManager.cluster_healthy", return_value=True),
+        patch("managers.node.NodeManager.is_healthy", return_value=True),
         patch("managers.node.NodeManager.decommission", return_value=None) as decommission,
         patch("ops.model.Application.planned_units", return_value=2),
         patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
@@ -112,7 +112,7 @@ def test_storage_detaching_decommission_fails(caplog):
             "managers.tls.TLSManager.client_tls_ready",
             new_callable=PropertyMock(return_value=False),
         ),
-        patch("managers.node.NodeManager.cluster_healthy", return_value=True),
+        patch("managers.node.NodeManager.is_healthy", return_value=True),
         patch("ops.model.Application.planned_units", return_value=1),
         patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
         patch(

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -89,6 +89,7 @@ def test_storage_detaching_decommission_fails(caplog):
     state = make_state(storage)
 
     with (
+        patch("charms.operator_libs_linux.v2.snap.Snap", return_value=MagicMock()),
         patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
         patch("ops.model.Application.planned_units", return_value=1),
         patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
@@ -98,7 +99,7 @@ def test_storage_detaching_decommission_fails(caplog):
         ),
     ):
         units.return_value = [MagicMock()]
-        with pytest.raises(scenario.errors.UncaughtSnapError) as e:
+        with pytest.raises(scenario.errors.UncaughtCharmError) as e:
             ctx.run(ctx.on.storage_detaching(storage), state)
 
         assert isinstance(e.value.__cause__, ExecError)

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -12,7 +12,7 @@ from ops import testing
 
 from charm import CassandraCharm
 from common.exceptions import ExecError
-from core.state import PEER_RELATION, DATA_STORAGE
+from core.state import DATA_STORAGE, PEER_RELATION
 
 
 def make_state(storage: testing.Storage, leader: bool = True):

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -97,11 +97,9 @@ def test_storage_detaching_decommission_fails(caplog):
             side_effect=ExecError(stdout="", stderr="error"),
         ),
     ):
-        units.return_value = [MagicMock()]  # один юнит
-        # Проверяем, что ctx.run вызывает UncaughtCharmError
+        units.return_value = [MagicMock()]
         with pytest.raises(scenario.errors.UncaughtCharmError) as e:
             ctx.run(ctx.on.storage_detaching(storage), state)
 
-        # Внутри e.value.__cause__ хранится оригинальный ExecError
         assert isinstance(e.value.__cause__, ExecError)
         assert "Failed to decommission unit" in caplog.text

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -12,7 +12,7 @@ from ops import testing
 
 from charm import CassandraCharm
 from common.exceptions import ExecError
-from core.state import PEER_RELATION
+from core.state import PEER_RELATION, DATA_STORAGE
 
 
 def make_state(storage: testing.Storage, leader: bool = True):
@@ -23,7 +23,7 @@ def make_state(storage: testing.Storage, leader: bool = True):
 def test_storage_detaching_cluster_unhealthy(caplog):
     """Charm should fail decommission if cluster is unhealthy."""
     ctx = testing.Context(CassandraCharm)
-    storage = testing.Storage(name="cassandra", index=0)
+    storage = testing.Storage(name=DATA_STORAGE, index=0)
     state = make_state(storage)
 
     with (
@@ -38,7 +38,7 @@ def test_storage_detaching_cluster_unhealthy(caplog):
 def test_storage_detaching_multiple_units_removal_logs_warning(caplog):
     """Charm should log a warning if more than one unit planned for removal."""
     ctx = testing.Context(CassandraCharm)
-    storage = testing.Storage(name="cassandra", index=0)
+    storage = testing.Storage(name=DATA_STORAGE, index=0)
     state = make_state(storage)
 
     with (
@@ -62,7 +62,7 @@ def test_storage_detaching_multiple_units_removal_logs_warning(caplog):
 def test_storage_detaching_success(caplog):
     """Charm should call decommission and log success message."""
     ctx = testing.Context(CassandraCharm)
-    storage = testing.Storage(name="cassandra", index=0)
+    storage = testing.Storage(name=DATA_STORAGE, index=0)
     state = make_state(storage)
 
     with (
@@ -85,7 +85,7 @@ def test_storage_detaching_success(caplog):
 def test_storage_detaching_decommission_fails(caplog):
     """Charm should log failure if decommission fails with ExecError."""
     ctx = testing.Context(CassandraCharm)
-    storage = testing.Storage(name="cassandra", index=0)
+    storage = testing.Storage(name=DATA_STORAGE, index=0)
     state = make_state(storage)
 
     with (

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -28,8 +28,12 @@ def test_storage_detaching_cluster_unhealthy(caplog):
 
     with (
         patch("charm.CassandraWorkload") as workload,
-        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=False),
-        patch("managers.cluster.ClusterManager.decommission") as decommission,
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch("managers.node.NodeManager.cluster_healthy", return_value=False),
+        patch("managers.node.NodeManager.decommission") as decommission,
     ):
         workload.return_value.generate_password.return_value = "password"
 
@@ -46,8 +50,12 @@ def test_storage_detaching_multiple_units_removal_logs_warning(caplog):
 
     with (
         patch("charm.CassandraWorkload") as workload,
-        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
-        patch("managers.cluster.ClusterManager.decommission", return_value=None) as decommission,
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch("managers.node.NodeManager.cluster_healthy", return_value=True),
+        patch("managers.node.NodeManager.decommission", return_value=None) as decommission,
         patch("ops.model.Application.planned_units", return_value=1),
         patch(
             "core.state.ApplicationState.units",
@@ -71,8 +79,12 @@ def test_storage_detaching_success(caplog):
 
     with (
         patch("charm.CassandraWorkload") as workload,
-        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
-        patch("managers.cluster.ClusterManager.decommission", return_value=None) as decommission,
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch("managers.node.NodeManager.cluster_healthy", return_value=True),
+        patch("managers.node.NodeManager.decommission", return_value=None) as decommission,
         patch("ops.model.Application.planned_units", return_value=2),
         patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
     ):
@@ -96,11 +108,15 @@ def test_storage_detaching_decommission_fails(caplog):
 
     with (
         patch("charm.CassandraWorkload") as workload,
-        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch("managers.node.NodeManager.cluster_healthy", return_value=True),
         patch("ops.model.Application.planned_units", return_value=1),
         patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
         patch(
-            "managers.cluster.ClusterManager.decommission",
+            "managers.node.NodeManager.decommission",
             side_effect=ExecError(stdout="", stderr="error"),
         ),
     ):

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+import logging
+from unittest.mock import patch, MagicMock, PropertyMock
+import pytest
+import ops
+from ops import testing
+import subprocess
+import scenario
+
+from charm import CassandraCharm
+from core.state import PEER_RELATION
+from common.exceptions import ExecError
+
+
+def make_state(storage: testing.Storage,leader: bool = True):
+    relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
+    return testing.State(leader=leader, relations={relation}, storages=frozenset([storage]))
+
+
+def test_storage_detaching_cluster_unhealthy(caplog):
+    """Charm should fail decommission if cluster is unhealthy."""
+    ctx = testing.Context(CassandraCharm)
+    storage = testing.Storage(name="cassandra", index=0)
+    state = make_state(storage)
+
+    with (
+        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=False),
+        patch("managers.cluster.ClusterManager.decommission") as decommission,
+    ):
+        with pytest.raises(Exception, match="Cluster is not healthy"):
+            ctx.run(ctx.on.storage_detaching(storage), state)
+        decommission.assert_not_called()
+
+
+def test_storage_detaching_multiple_units_removal_logs_warning(caplog):
+    """Charm should log a warning if more than one unit planned for removal."""
+    ctx = testing.Context(CassandraCharm)
+    storage = testing.Storage(name="cassandra", index=0)
+    state = make_state(storage)
+
+    with (
+        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
+        patch("managers.cluster.ClusterManager.decommission") as decommission,
+        patch("ops.model.Application.planned_units", return_value=1),
+        patch("core.state.ApplicationState.units", new_callable=PropertyMock(return_value=[MagicMock(), MagicMock(), MagicMock()])) as units,
+    ):
+        decommission.return_value = None
+
+        with caplog.at_level(logging.WARNING):
+            ctx.run(ctx.on.storage_detaching(storage), state)
+
+        assert "More than one unit removing" in caplog.text
+        decommission.assert_called_once()
+
+
+def test_storage_detaching_success(caplog):
+    """Charm should call decommission and log success message."""
+    ctx = testing.Context(CassandraCharm)
+    storage = testing.Storage(name="cassandra", index=0)
+    state = make_state(storage)
+
+    with (
+        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
+        patch("managers.cluster.ClusterManager.decommission") as decommission,
+        patch("ops.model.Application.planned_units", return_value=2),
+        patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
+    ):
+        units.return_value = [MagicMock(), MagicMock(), MagicMock()]
+        decommission.return_value = None
+
+        with caplog.at_level(logging.INFO):
+            ctx.run(ctx.on.storage_detaching(storage), state)
+
+        decommission.assert_called_once()
+        assert "node decommissioning" in caplog.text
+        assert "Storage deatached" in caplog.text
+
+
+def test_storage_detaching_decommission_fails(caplog):
+    """Charm should log failure if decommission fails with ExecError."""
+    ctx = testing.Context(CassandraCharm)
+    storage = testing.Storage(name="cassandra", index=0)
+    state = make_state(storage)
+
+    with (
+        patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
+        patch("ops.model.Application.planned_units", return_value=1),
+        patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
+        patch("managers.cluster.ClusterManager.decommission", side_effect=ExecError(
+            stdout="", stderr="error"
+        )),
+    ):
+        units.return_value = [MagicMock()]  # один юнит
+        # Проверяем, что ctx.run вызывает UncaughtCharmError
+        with pytest.raises(scenario.errors.UncaughtCharmError) as e:
+            ctx.run(ctx.on.storage_detaching(storage), state)
+
+        # Внутри e.value.__cause__ хранится оригинальный ExecError
+        assert isinstance(e.value.__cause__, ExecError)
+        assert "Failed to decommission unit" in caplog.text

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -98,7 +98,7 @@ def test_storage_detaching_decommission_fails(caplog):
         ),
     ):
         units.return_value = [MagicMock()]
-        with pytest.raises(scenario.errors.UncaughtCharmError) as e:
+        with pytest.raises(scenario.errors.UncaughtSnapError) as e:
             ctx.run(ctx.on.storage_detaching(storage), state)
 
         assert isinstance(e.value.__cause__, ExecError)

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -4,19 +4,18 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import logging
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import pytest
-import ops
-from ops import testing
-import subprocess
 import scenario
+from ops import testing
 
 from charm import CassandraCharm
-from core.state import PEER_RELATION
 from common.exceptions import ExecError
+from core.state import PEER_RELATION
 
 
-def make_state(storage: testing.Storage,leader: bool = True):
+def make_state(storage: testing.Storage, leader: bool = True):
     relation = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
     return testing.State(leader=leader, relations={relation}, storages=frozenset([storage]))
 
@@ -46,7 +45,10 @@ def test_storage_detaching_multiple_units_removal_logs_warning(caplog):
         patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
         patch("managers.cluster.ClusterManager.decommission") as decommission,
         patch("ops.model.Application.planned_units", return_value=1),
-        patch("core.state.ApplicationState.units", new_callable=PropertyMock(return_value=[MagicMock(), MagicMock(), MagicMock()])) as units,
+        patch(
+            "core.state.ApplicationState.units",
+            new_callable=PropertyMock(return_value=[MagicMock(), MagicMock(), MagicMock()]),
+        ),
     ):
         decommission.return_value = None
 
@@ -90,9 +92,10 @@ def test_storage_detaching_decommission_fails(caplog):
         patch("managers.cluster.ClusterManager.cluster_healthy", return_value=True),
         patch("ops.model.Application.planned_units", return_value=1),
         patch("core.state.ApplicationState.units", new_callable=PropertyMock) as units,
-        patch("managers.cluster.ClusterManager.decommission", side_effect=ExecError(
-            stdout="", stderr="error"
-        )),
+        patch(
+            "managers.cluster.ClusterManager.decommission",
+            side_effect=ExecError(stdout="", stderr="error"),
+        ),
     ):
         units.return_value = [MagicMock()]  # один юнит
         # Проверяем, что ctx.run вызывает UncaughtCharmError

--- a/tests/unit/test_scale.py
+++ b/tests/unit/test_scale.py
@@ -85,7 +85,7 @@ def test_storage_detaching_success(caplog):
 
         decommission.assert_called_once()
         assert "node decommissioning" in caplog.text
-        assert "Storage deatached" in caplog.text
+        assert "storage-detaching event completed" in caplog.text
 
 
 def test_storage_detaching_decommission_fails(caplog):


### PR DESCRIPTION
### PR Summary

This PR implements proper handling of node decommissioning when a Juju unit is removed, ensuring safe removal and clear logging.

### Key Changes

* **\_on\_storage\_detaching hook** – Added to handle single-unit removal with proper decommissioning.
* **Health checks** – Cluster health is verified before attempting decommissioning.
* **Logging improvements** – Warnings and errors are logged clearly for easier debugging.
* **Tests** – Comprehensive unit and integration tests covering decommissioning scenarios.