### PR TITLE
[DPE-8321] Improve integration tests stability

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -4,7 +4,7 @@ on:
       artifact-prefix:
         description: |
           Prefix for charm package GitHub artifact(s)
-          
+
           Use canonical/data-platform-workflows build_charm.yaml to build the charm(s)
         required: true
         type: string
@@ -84,7 +84,7 @@ jobs:
     needs:
       - collect-integration-tests
     runs-on: ${{ matrix.job.runner }}
-    timeout-minutes: 217  # Sum of steps `timeout-minutes` + 5
+    timeout-minutes: 217 # Sum of steps `timeout-minutes` + 5
     steps:
       - name: Disk usage
         shell: bash
@@ -136,7 +136,7 @@ jobs:
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
       - name: Debug spread failure
         uses: mxschmitt/action-tmate@v3
-        if: ${{ steps.spread.outcome == 'failure' }}
+        if: ${{ failure() || steps.spread.outcome == 'failure' }}
       - name: Upload Allure results
         timeout-minutes: 3
         # Only upload results from one spread system & one spread variant
@@ -177,7 +177,7 @@ jobs:
           # "testing" is default model created by concierge
           sudo juju switch concierge-lxd:admin/test-cas
           mkdir -p ~/logs/
-  
+
       - name: juju status lxd
         timeout-minutes: 1
         if: ${{ steps.check-lxd-model.outputs.exists == 'true' && !contains(matrix.job.spread_job, 'juju29') && (success() || (failure() && steps.spread.outcome == 'failure')) }}
@@ -201,7 +201,7 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-    
+
       - name: Select k8s model
         timeout-minutes: 1
         # `!contains(matrix.job.spread_job, 'juju29')` workaround for juju 2 error:
@@ -215,7 +215,7 @@ jobs:
           # "testing" is default model created by concierge
           sudo juju switch concierge-microk8s:admin/test-cas
           mkdir -p ~/logs/
-  
+
       - name: juju status k8s
         timeout-minutes: 1
         if: ${{ steps.check-k8s-model.outputs.exists == 'true' && !contains(matrix.job.spread_job, 'juju29') && (success() || (failure() && steps.spread.outcome == 'failure')) }}
@@ -231,9 +231,9 @@ jobs:
         if: ${{ steps.check-k8s-model.outputs.exists == 'true' && success() || (failure() && steps.spread.outcome == 'failure') }}
         run: sudo juju switch concierge-microk8s:admin/test-cas && sudo juju destroy-model test-cas --destroy-storage --force --no-prompt
 
-# end of k8s
+      # end of k8s
 
-      - name: jhack tail 
+      - name: jhack tail
         timeout-minutes: 3
         if: ${{ !contains(matrix.job.spread_job, 'juju29') && (success() || (failure() && steps.spread.outcome == 'failure')) }}
         run: sudo jhack tail --printer raw --replay --no-watch | tee ~/logs/jhack-tail.txt

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -86,14 +86,29 @@ jobs:
     runs-on: ${{ matrix.job.runner }}
     timeout-minutes: 217  # Sum of steps `timeout-minutes` + 5
     steps:
-      - name: Free up disk space
-        timeout-minutes: 3
+      - name: Disk usage
+        shell: bash
         run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /opt/hostedtoolcache/
-          printf '\nDisk usage after cleanup\n'
+          sudo rm -rf \
+            /opt/google \
+            /opt/hostedtoolcache \
+            /opt/microsoft/powershell \
+            /opt/microsoft/msedge \
+            "$AGENT_TOOLSDIRECTORY" \
+            /usr/lib/firefox \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/gradle* \
+            /usr/share/miniconda \
+            /usr/share/sbt \
+            /usr/share/swift \
+            /home/linuxbrew
+          pipx uninstall-all
+          printf '\nDisk usage\n'
           df --human-readable
       - name: Checkout
         timeout-minutes: 3

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -134,6 +134,9 @@ jobs:
         # https://github.com/canonical/charmcraft/issues/2105 and
         # https://github.com/canonical/charmcraft/issues/2130 fixed
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
+      - name: Debug spread failure
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ steps.spread.outcome == 'failure' }}
       - name: Upload Allure results
         timeout-minutes: 3
         # Only upload results from one spread system & one spread variant

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -134,9 +134,6 @@ jobs:
         # https://github.com/canonical/charmcraft/issues/2105 and
         # https://github.com/canonical/charmcraft/issues/2130 fixed
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
-      - name: Debug spread failure
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() || steps.spread.outcome == 'failure' }}
       - name: Upload Allure results
         timeout-minutes: 3
         # Only upload results from one spread system & one spread variant

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -12,7 +12,7 @@ providers:
     addons:
       - rbac
       - hostpath-storage
-      - dns
+      - dns:8.8.8.8
       - minio
       - metallb:10.64.140.43-10.64.140.49
     

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -14,7 +14,6 @@ providers:
       - rbac
       - hostpath-storage
       - dns
-      - minio
       - metallb:10.64.140.43-10.64.140.49
     
 host:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -11,8 +11,9 @@ providers:
     bootstrap: true
     channel: 1.34-strict/stable
     addons:
-      - hostpath-storage
       - dns
+      - rbac
+      - hostpath-storage
       - metallb:10.64.140.43-10.64.140.49
     
 host:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -5,13 +5,12 @@ providers:
   lxd:
     enable: true
     bootstrap: true
-    channel: 6/stable
+    channel: 5.21/stable
   microk8s:
     enable: true
     bootstrap: true
     channel: 1.34-strict/stable
     addons:
-      - rbac
       - hostpath-storage
       - dns
       - metallb:10.64.140.43-10.64.140.49

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -9,7 +9,7 @@ providers:
   microk8s:
     enable: true
     bootstrap: true
-    channel: 1.32-strict
+    channel: 1.34-strict/stable
     addons:
       - rbac
       - hostpath-storage

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -5,11 +5,11 @@ providers:
   lxd:
     enable: true
     bootstrap: true
-    channel: 5.21/stable
+    channel: 6/stable
   microk8s:
     enable: true
     bootstrap: true
-    channel: 1.34-strict/stable
+    channel: 1.32-strict/stable
     addons:
       - dns
       - rbac

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -5,6 +5,7 @@ providers:
   lxd:
     enable: true
     bootstrap: true
+    channel: 6/stable
   microk8s:
     enable: true
     bootstrap: true

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -12,7 +12,7 @@ providers:
     addons:
       - rbac
       - hostpath-storage
-      - dns:8.8.8.8
+      - dns
       - minio
       - metallb:10.64.140.43-10.64.140.49
     

--- a/spread.yaml
+++ b/spread.yaml
@@ -110,11 +110,15 @@ prepare: |
   snap install microk8s --channel 1.34-strict/stable
   microk8s status --wait-ready
   microk8s enable dns
+  microk8s status --wait-ready
+  microk8s kubectl rollout status deployments/coredns -n kube-system -w
+  microk8s enable rbac
+  microk8s status --wait-ready
   microk8s enable hostpath-storage
-  microk8s enable metallb:10.64.140.43-10.64.140.49
   microk8s status --wait-ready
   microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
-  microk8s kubectl rollout status deployments/coredns -n kube-system -w
+  microk8s enable metallb:10.64.140.43-10.64.140.49
+  microk8s status --wait-ready
   microk8s kubectl rollout status daemonset.apps/speaker -n metallb-system -w
 
   # Install charmcraft & pipx (on lxd-vm backend)

--- a/spread.yaml
+++ b/spread.yaml
@@ -109,8 +109,10 @@ prepare: |
 
   snap install microk8s --channel 1.34-strict/stable
   microk8s status --wait-ready
-  microk8s disable dns
-  microk8s enable dns:$(resolvectl status | grep "Current DNS Server" | awk '{print $NF}')   # This sets the dns to your current nameserver
+  microk8s enable dns
+  microk8s enable rbac
+  microk8s enable hostpath-storage
+  microk8s enable metallb:10.64.140.43-10.64.140.49
   microk8s status --wait-ready
 
   # Install charmcraft & pipx (on lxd-vm backend)

--- a/spread.yaml
+++ b/spread.yaml
@@ -85,7 +85,7 @@ backends:
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables
     environment:
-      CI: '$(HOST: echo $CI)'
+      CI: "$(HOST: echo $CI)"
     systems:
       - ubuntu-24.04:
           username: runner
@@ -102,6 +102,8 @@ environment:
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
   CONCIERGE_JUJU_CHANNEL/juju35: 3.5/stable
 prepare: |
+  systemctl stop apparmor
+
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
@@ -145,4 +147,5 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
+
 # Only restore on lxd backend—no need to restore on CI

--- a/spread.yaml
+++ b/spread.yaml
@@ -116,7 +116,7 @@ prepare-each: |
 
   # Wait for all snap changes to gone to avoid error:
   # level=ERROR msg="concierge failed" error="failed to install MicroK8s: failed to install snap: command failed: exit status 10"
-  while snap changes | grep Doing; do sleep 1; done
+  (while snap changes | grep Doing; do sleep 1; done)
 
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
   concierge prepare --trace

--- a/spread.yaml
+++ b/spread.yaml
@@ -110,10 +110,12 @@ prepare: |
   snap install microk8s --channel 1.34-strict/stable
   microk8s status --wait-ready
   microk8s enable dns
-  microk8s enable rbac
   microk8s enable hostpath-storage
   microk8s enable metallb:10.64.140.43-10.64.140.49
   microk8s status --wait-ready
+  microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
+  microk8s kubectl rollout status deployments/coredns -n kube-system -w
+  microk8s kubectl rollout status daemonset.apps/speaker -n metallb-system -w
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace

--- a/spread.yaml
+++ b/spread.yaml
@@ -118,10 +118,6 @@ prepare-each: |
   # level=ERROR msg="concierge failed" error="failed to install MicroK8s: failed to install snap: command failed: exit status 10"
   while snap changes | grep Doing; do sleep 1; done
 
-  # Disable extension to ensure dns is set to 8.8.8.8 (via concierge.yaml) to avoid error:
-  # ERROR resolving with preferred channel: Post "https://api.charmhub.io/v2/charms/refresh": dial tcp: lookup api.charmhub.io on 10.152.183.10:53: read udp 10.1.242.78:36045->10.152.183.10:53: i/o timeout
-  sudo microk8s disable dns
-
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
   concierge prepare --trace
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -107,18 +107,25 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  snap install microk8s --channel 1.34-strict/stable
+  snap install lxd --channel 6/stable
+  cat <<EOF | lxd init --preseed
+  networks:
+  - name: lxdbr0
+    type: bridge
+    config:
+      ipv4.address: auto
+      ipv6.address: none
+  EOF
+
+  snap install microk8s --channel 1.32-strict/stable
   microk8s status --wait-ready
   microk8s enable dns
-  microk8s status --wait-ready
-  microk8s kubectl rollout status deployments/coredns -n kube-system -w
-  microk8s enable rbac
-  microk8s status --wait-ready
   microk8s enable hostpath-storage
-  microk8s status --wait-ready
-  microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
+  microk8s enable rbac
   microk8s enable metallb:10.64.140.43-10.64.140.49
   microk8s status --wait-ready
+  microk8s kubectl rollout status deployments/coredns -n kube-system -w
+  microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
   microk8s kubectl rollout status daemonset.apps/speaker -n metallb-system -w
 
   # Install charmcraft & pipx (on lxd-vm backend)

--- a/spread.yaml
+++ b/spread.yaml
@@ -107,6 +107,12 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
+  snap install microk8s --channel 1.34-strict/stable
+  microk8s status --wait-ready
+  microk8s disable dns
+  microk8s enable dns:$(resolvectl status | grep "Current DNS Server" | awk '{print $NF}')   # This sets the dns to your current nameserver
+  microk8s status --wait-ready
+
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -109,27 +109,6 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  snap install lxd --channel 6/stable
-  cat <<EOF | lxd init --preseed
-  networks:
-  - name: lxdbr0
-    type: bridge
-    config:
-      ipv4.address: auto
-      ipv6.address: none
-  EOF
-
-  snap install microk8s --channel 1.32-strict/stable
-  microk8s status --wait-ready
-  microk8s enable dns
-  microk8s enable hostpath-storage
-  microk8s enable rbac
-  microk8s enable metallb:10.64.140.43-10.64.140.49
-  microk8s status --wait-ready
-  microk8s kubectl rollout status deployments/coredns -n kube-system -w
-  microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
-  microk8s kubectl rollout status daemonset.apps/speaker -n metallb-system -w
-
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -113,6 +113,15 @@ prepare: |
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"
+
+  # Wait for all snap changes to gone to avoid error:
+  # level=ERROR msg="concierge failed" error="failed to install MicroK8s: failed to install snap: command failed: exit status 10"
+  while snap changes | grep Doing; do sleep 1; done
+
+  # Disable extension to ensure dns is set to 8.8.8.8 (via concierge.yaml) to avoid error:
+  # ERROR resolving with preferred channel: Post "https://api.charmhub.io/v2/charms/refresh": dial tcp: lookup api.charmhub.io on 10.152.183.10:53: read udp 10.1.242.78:36045->10.152.183.10:53: i/o timeout
+  sudo microk8s disable dns
+
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
   concierge prepare --trace
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -102,8 +102,6 @@ environment:
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
   CONCIERGE_JUJU_CHANNEL/juju35: 3.5/stable
 prepare: |
-  systemctl stop apparmor
-
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,7 +18,7 @@ from tenacity import Retrying, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
 COS_METRICS_PORT = 7071
-DEFAULT_MICROK8S_CHANNEL = "1.32-strict"
+DEFAULT_MICROK8S_CHANNEL = "1.34-strict/stable"
 
 
 @contextmanager

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,7 +18,7 @@ from tenacity import Retrying, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
 COS_METRICS_PORT = 7071
-DEFAULT_MICROK8S_CHANNEL = "1.34-strict/stable"
+DEFAULT_MICROK8S_CHANNEL = "1.32-strict/stable"
 
 
 @contextmanager


### PR DESCRIPTION
Changes:
* Free up disk space action is upgraded to [Spark version](https://github.com/canonical/spark-k8s-bundle/blob/bb9fbec54727aa9d1a01d6bd3b59e6b53be14007/.github/actions/run-test/action.yaml#L60C6-L83C28) and execution timeout was removed
* We wait for all the snap changes to complete prior running every integration test

# Open Letter to Hobbyists

After spending 15 hours trying to fix random networking issues somewhere in microk8s / lxd / systemd-networkd / juju / snap / concierge / spread / apparmor chain, I figured out that I'm not kind of person that can handle this. Here the journalctl logs with LXD's `ERROR failed to bootstrap model: cancelled` and MicroK8s's `ERROR resolving with preferred channel: Post "https://api.charmhub.io/v2/charms/refresh": dial tcp: lookup api.charmhub.io: i/o timeout` errors, **that will still continue to haunt us** til end of our lives:
* [lxd error.log](https://github.com/user-attachments/files/22599264/lxd.error.log)
* [microk8s error.log](https://github.com/user-attachments/files/22599266/microk8s.error.log)