### PR TITLE
[DPE-8410] Enable TLS for DatabaseManager

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -59,10 +59,10 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
         )
         database_manager = DatabaseManager(
             workload=self.workload,
+            tls_manager=self.tls_manager,
             hosts=[self.state.unit.ip],
             user=CASSANDRA_ADMIN_USERNAME,
             password=self.state.cluster.operator_password_secret,
-            enable_ssl=self.state.unit.client_tls.ready,
         )
         bootstrap_manager = RollingOpsManager(
             charm=self, relation="bootstrap", callback=self.bootstrap

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,9 +58,11 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
             authentication=True,
         )
         database_manager = DatabaseManager(
+            workload=self.workload,
             hosts=[self.state.unit.ip],
             user=CASSANDRA_ADMIN_USERNAME,
             password=self.state.cluster.operator_password_secret,
+            enable_ssl=self.state.unit.client_tls.ready,
         )
         bootstrap_manager = RollingOpsManager(
             charm=self, relation="bootstrap", callback=self.bootstrap

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -53,12 +53,24 @@ class CassandraPaths:
         return self.data_dir / "saved_caches"
 
     def get_truststore(self, scope: TLSScope) -> pathops.PathProtocol:
-        """Get keystore path for the scope."""
+        """Get truststore path for the TLS scope."""
         return self.tls_dir / f"{scope.value}-truststore.jks"
 
     def get_keystore(self, scope: TLSScope) -> pathops.PathProtocol:
-        """Get keystore path for the scope."""
+        """Get keystore path for the TLS scope."""
         return self.tls_dir / f"{scope.value}-keystore.p12"
+
+    def get_ca(self, scope: TLSScope) -> pathops.PathProtocol:
+        """GET ca path for the TLS scope."""
+        return self.tls_dir / f"{scope.value}-ca.pem"
+
+    def get_certificate(self, scope: TLSScope) -> pathops.PathProtocol:
+        """Get certificate path for the TLS scope."""
+        return self.tls_dir / f"{scope.value}-unit.pem"
+
+    def get_private_key(self, scope: TLSScope) -> pathops.PathProtocol:
+        """Get private key path for the TLS scope."""
+        return self.tls_dir / f"{scope.value}-private.key"
 
     @property
     def jmx_exporter(self) -> pathops.PathProtocol:

--- a/src/core/workload.py
+++ b/src/core/workload.py
@@ -61,7 +61,7 @@ class CassandraPaths:
         return self.tls_dir / f"{scope.value}-keystore.p12"
 
     def get_ca(self, scope: TLSScope) -> pathops.PathProtocol:
-        """GET ca path for the TLS scope."""
+        """Get ca path for the TLS scope."""
         return self.tls_dir / f"{scope.value}-ca.pem"
 
     def get_certificate(self, scope: TLSScope) -> pathops.PathProtocol:

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -367,11 +367,7 @@ class CassandraEvents(Object):
     def _are_seeds_reachable(self) -> bool:
         return self.state.unit.is_seed or any(
             unit.workload_state == UnitWorkloadState.ACTIVE
-            and DatabaseManager(
-                hosts=[unit.ip],
-                user=CASSANDRA_ADMIN_USERNAME,
-                password=self.state.cluster.operator_password_secret,
-            ).check()
+            and self.database_manager.check(hosts=[unit.ip])
             for unit in self.state.other_seed_units
         )
 

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -6,6 +6,7 @@
 
 import logging
 from contextlib import contextmanager
+from ssl import CERT_REQUIRED, PROTOCOL_TLS, SSLContext
 from typing import Generator
 
 from cassandra import AuthenticationFailed
@@ -20,6 +21,8 @@ from cassandra.cluster import (
 from cassandra.policies import DCAwareRoundRobinPolicy, TokenAwarePolicy
 
 from core.literals import CASSANDRA_ADMIN_USERNAME
+from core.state import TLSScope
+from core.workload import WorkloadBase
 
 logger = logging.getLogger(__name__)
 
@@ -29,18 +32,37 @@ _CASSANDRA_DEFAULT_CREDENTIALS = "cassandra"
 class DatabaseManager:
     """Manager of Cassandra database."""
 
-    def __init__(self, hosts: list[str], user: str, password: str):
+    def __init__(
+        self,
+        workload: WorkloadBase,
+        hosts: list[str],
+        user: str,
+        password: str,
+        enable_ssl: bool = False,
+    ):
         self.execution_profile = ExecutionProfile(
             load_balancing_policy=TokenAwarePolicy(DCAwareRoundRobinPolicy())
         )
         self.auth_provider = (
             PlainTextAuthProvider(username=user, password=password) if user and password else None
         )
+        if enable_ssl:
+            self.ssl_context = SSLContext(PROTOCOL_TLS)
+            self.ssl_context.load_cert_chain(
+                certfile=workload.cassandra_paths.get_certificate(TLSScope.CLIENT).as_posix(),
+                keyfile=workload.cassandra_paths.get_private_key(TLSScope.CLIENT).as_posix(),
+            )
+            self.ssl_context.verify_mode = CERT_REQUIRED
+            self.ssl_context.load_verify_locations(
+                cafile=workload.cassandra_paths.get_ca(TLSScope.CLIENT).as_posix()
+            )
+        else:
+            self.ssl_context = None
         self.hosts = hosts
 
         return
 
-    def check(self) -> bool:
+    def check(self, hosts: list[str] | None = None) -> bool:
         """Check connectivity to the Cassandra.
 
         Returns positive even when cluster cannot achieve consistency level for the authentication.
@@ -49,7 +71,7 @@ class DatabaseManager:
             whether Cassandra service on this node is ready to accept connections.
         """
         try:
-            with self._session() as session:
+            with self._session(hosts=hosts) as session:
                 session.execute("SELECT release_version FROM system.local")
                 logger.debug(f"Reachability check success: {','.join(self.hosts)}")
                 return True
@@ -110,6 +132,7 @@ class DatabaseManager:
             contact_points=hosts or self.hosts,
             protocol_version=5,
             execution_profiles={EXEC_PROFILE_DEFAULT: self.execution_profile},
+            ssl_context=self.ssl_context,
         )
         session = cluster.connect()
         if keyspace:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -55,12 +55,9 @@ class TLSManager:
     @property
     def client_tls_ready(self) -> bool:
         """Return the readiness of client TLS configuration files."""
-        return all(
-            self.workload.path_exists(f.as_posix())
-            for f in [
-                self.workload.cassandra_paths.get_truststore(TLSScope.CLIENT),
-                self.workload.cassandra_paths.get_keystore(TLSScope.CLIENT),
-            ]
+        return (
+            self.workload.cassandra_paths.get_truststore(TLSScope.CLIENT).exists()
+            and self.workload.cassandra_paths.get_keystore(TLSScope.CLIENT).exists()
         )
 
     def build_sans(self, sans_dns: list[str], sans_ip: list[str]) -> Sans:

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -37,6 +37,10 @@ def test_start_custom_secret(bad_secret: bool):
         patch("charm.CassandraWorkload") as workload,
         patch("managers.tls.TLSManager.configure"),
         patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=True),
         ),
@@ -75,6 +79,10 @@ def test_update_custom_secret():
 
     with (
         patch("managers.database.DatabaseManager.update_role_password") as update_role_password,
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch("charm.CassandraWorkload") as workload,
     ):
         workload.return_value.generate_password.return_value = "password"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -30,6 +30,10 @@ def test_start_change_password():
         patch("charm.CassandraWorkload") as workload,
         patch("managers.tls.TLSManager.configure"),
         patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch(
             "managers.cluster.ClusterManager.is_healthy",
             new_callable=PropertyMock(return_value=True),
         ),
@@ -58,6 +62,10 @@ def test_start_subordinate_only_after_leader_active():
         ),
         patch("charm.CassandraCharm.setup_internal_certificates", return_value=True),
         patch("charm.CassandraWorkload") as workload,
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch(
             "charms.rolling_ops.v0.rollingops.RollingOpsManager._on_acquire_lock", autospec=True
         ) as bootstrap,
@@ -104,6 +112,10 @@ def test_start_subordinate_only_after_seed_active(workload_active: bool, seed_ac
         patch(
             "managers.cluster.ClusterManager.network_address", return_value=("1.1.1.1", "hostname")
         ),
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch("managers.database.DatabaseManager.check", return_value=seed_active),
         patch("charm.CassandraCharm.setup_internal_certificates", return_value=True),
         patch("charm.CassandraWorkload") as workload,
@@ -129,6 +141,10 @@ def test_start_invalid_config():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch("charm.CassandraCharm.setup_internal_certificates", return_value=True),
         patch("charm.CassandraWorkload") as workload,
         patch(
@@ -155,6 +171,10 @@ def test_config_changed_invalid_config():
     with (
         patch("managers.config.ConfigManager.render_env"),
         patch("managers.config.ConfigManager.render_cassandra_config"),
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch("charm.CassandraCharm.setup_internal_certificates", return_value=True),
         patch("charm.CassandraWorkload") as workload,
     ):
@@ -179,6 +199,10 @@ def test_config_changed(env_changed: bool, cassandra_config_changed: bool):
             return_value=cassandra_config_changed,
         ) as render_cassandra_config,
         patch("managers.database.DatabaseManager.update_role_password"),
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch("charm.CassandraWorkload") as workload,
         patch("charm.CassandraCharm.setup_internal_certificates", return_value=True),
         patch(

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -350,7 +350,13 @@ def test_tls_relation_created_sets_tls_state(ctx, is_leader):
         leader=is_leader, relations={relation, bootstrap_relation, client_tls_relation}
     )
 
-    with patch("charm.CassandraWorkload") as workload:
+    with (
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
+        patch("charm.CassandraWorkload") as workload,
+    ):
         workload.return_value.generate_password.return_value = "password"
 
         state_out = ctx.run(ctx.on.relation_created(client_tls_relation), state)
@@ -372,6 +378,10 @@ def test_tls_default_certificates_files_setup(ctx):
         patch("managers.config.ConfigManager.render_env"),
         patch("managers.config.ConfigManager.render_cassandra_config"),
         patch("managers.tls.TLSManager.configure"),
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch("managers.database.DatabaseManager.init_admin"),
         patch(
             "managers.cluster.ClusterManager.is_healthy",
@@ -414,6 +424,10 @@ def test_tls_default_certificates_files_setup(ctx):
         patch("managers.config.ConfigManager.render_env"),
         patch("managers.config.ConfigManager.render_cassandra_config"),
         patch("managers.tls.TLSManager.configure"),
+        patch(
+            "managers.tls.TLSManager.client_tls_ready",
+            new_callable=PropertyMock(return_value=False),
+        ),
         patch(
             "core.state.ClusterContext.internal_ca",
             new_callable=PropertyMock(return_value=default_tls_context.default_provider_ca_crt),


### PR DESCRIPTION
Currently, database manager doesn’t account of TLS client relation. So, if that relation is established, password change & seed nodes pinging (introduced in handling full cluster restart PR) operations will fail. This PR fixes it.