### PR TITLE
Fix scaling down

### DIFF
--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -286,14 +286,8 @@ class CassandraEvents(Object):
         if not self.state.unit.is_ready:
             logger.debug("Exiting on_peer_relation_departed due to unit not being ready")
             return
-        if event.departing_unit == self.charm.unit:
-            if not self.state.unit.is_operational:
-                logger.debug(
-                    "Deferring on_peer_relation_departed due to unit not being operational"
-                )
-                event.defer()
-                return
-        elif self.charm.unit.is_leader():
+        
+        if event.departing_unit != self.charm.unit and self.charm.unit.is_leader():
             if not self.state.unit.is_config_change_eligible:
                 logger.debug(
                     "Deferring on_peer_relation_departed due to unit not being ready change config"

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -286,7 +286,7 @@ class CassandraEvents(Object):
         if not self.state.unit.is_ready:
             logger.debug("Exiting on_peer_relation_departed due to unit not being ready")
             return
-        
+
         if event.departing_unit != self.charm.unit and self.charm.unit.is_leader():
             if not self.state.unit.is_config_change_eligible:
                 logger.debug(

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -293,7 +293,6 @@ class CassandraEvents(Object):
                 )
                 event.defer()
                 return
-            self.node_manager.decommission()
         elif self.charm.unit.is_leader():
             if not self.state.unit.is_config_change_eligible:
                 logger.debug(


### PR DESCRIPTION
Refactor: Remove duplicate node decommission call from `_on_peer_relation_departed`

Previously, `self.node_manager.decommission()` was being called in both `_on_peer_relation_departed` and `_on_storage_detaching hooks`. This led to duplicated decommission logic when a unit is being removed, increasing the risk of errors or inconsistent cluster state. It was not caught in tests, because If a node is already in the process of decommissioning or has been decommissioned, nodetool decommission may simply ignore a second call or issue a warning, but it will not cause a critical error. In practice, calling decommission twice is redundant but does not break the cluster.

This PR removes the call from `_on_peer_relation_departed` while keeping it in `_on_storage_detaching`, which is the proper hook for handling unit decommissioning during storage removal.