### PR TITLE
[DPE-8599] Repair management & high-availability for system_auth

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -134,7 +134,6 @@ jobs:
         # https://github.com/canonical/charmcraft/issues/2105 and
         # https://github.com/canonical/charmcraft/issues/2130 fixed
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
-
       - name: Upload Allure results
         timeout-minutes: 3
         # Only upload results from one spread system & one spread variant
@@ -148,7 +147,7 @@ jobs:
           if-no-files-found: error
       - timeout-minutes: 1
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
-        run: snap list    
+        run: snap list
       - timeout-minutes: 1
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
         run: sudo juju controllers

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -401,6 +401,15 @@ class UnitContext(RelationState):
         self._field_setter_wrapper("truststore-password-secret", value)
 
     @property
+    def auth_repaired(self) -> bool:
+        """TODO."""
+        return bool(self.relation_data.get("auth-repaired", ""))
+
+    @auth_repaired.setter
+    def auth_repaired(self, value: bool) -> None:
+        self._field_setter_wrapper("auth-repaired", str(value))
+
+    @property
     def is_seed(self) -> bool:
         """Whether this unit's `peer_url` present in `ClusterContext.seeds`."""
         return self.peer_url in self.seeds
@@ -552,6 +561,15 @@ class ClusterContext(RelationState):
     @operator_password_secret.setter
     def operator_password_secret(self, value: str) -> None:
         self._field_setter_wrapper("operator-password", value)
+
+    @property
+    def auth_repairing(self) -> bool:
+        """TODO."""
+        return bool(self.relation_data.get("auth-repairing", ""))
+
+    @auth_repairing.setter
+    def auth_repairing(self, value: bool) -> None:
+        self._field_setter_wrapper("auth-repairing", str(value))
 
 
 class ApplicationState(Object):

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -401,6 +401,15 @@ class UnitContext(RelationState):
         self._field_setter_wrapper("truststore-password-secret", value)
 
     @property
+    def update_auth_rf_ongoing(self) -> bool:
+        """TODO."""
+        return bool(self.relation_data.get("update_auth_rf_ongoing"))
+
+    @update_auth_rf_ongoing.setter
+    def update_auth_rf_ongoing(self, value: bool) -> None:
+        self._field_setter_wrapper("update_auth_rf_ongoing", str(value) if value else "")
+
+    @property
     def is_seed(self) -> bool:
         """Whether this unit's `peer_url` present in `ClusterContext.seeds`."""
         return self.peer_url in self.seeds

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -401,15 +401,6 @@ class UnitContext(RelationState):
         self._field_setter_wrapper("truststore-password-secret", value)
 
     @property
-    def update_auth_rf_ongoing(self) -> bool:
-        """TODO."""
-        return bool(self.relation_data.get("update_auth_rf_ongoing"))
-
-    @update_auth_rf_ongoing.setter
-    def update_auth_rf_ongoing(self, value: bool) -> None:
-        self._field_setter_wrapper("update_auth_rf_ongoing", str(value) if value else "")
-
-    @property
     def is_seed(self) -> bool:
         """Whether this unit's `peer_url` present in `ClusterContext.seeds`."""
         return self.peer_url in self.seeds

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -100,10 +100,16 @@ class UnitWorkloadState(StrEnum):
 
 
 class AuthRepairState(StrEnum):
-    """TODO."""
+    """Current state of the system_auth keyspace repair process."""
 
+    """Auth repair isn't scheduled."""
     UNPLANNED = ""
+    """Auth repair is scheduled and will be done when cluster stabilizes."""
     PENDING = "pending"
+    """Auth repair should be proceeded on all the units.
+
+    Completion of this process should be signalized with UnitContext.auth_repaired.
+    """
     WAITING_FOR_REPAIR = "waiting_for_repair"
 
 
@@ -410,7 +416,10 @@ class UnitContext(RelationState):
 
     @property
     def auth_repaired(self) -> bool:
-        """TODO."""
+        """Signalization of successful system_auth repair completion.
+
+        See AuthRepairState for more information.
+        """
         return bool(self.relation_data.get("auth-repaired", ""))
 
     @auth_repaired.setter
@@ -572,12 +581,11 @@ class ClusterContext(RelationState):
 
     @property
     def auth_repair(self) -> AuthRepairState:
-        """TODO."""
+        """Current state of the system_auth keyspace repair process."""
         return self.relation_data.get("auth-repair", AuthRepairState.UNPLANNED)
 
     @auth_repair.setter
     def auth_repair(self, value: AuthRepairState) -> None:
-        """TODO."""
         self._field_setter_wrapper("auth-repair", value.value)
 
 

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -99,6 +99,14 @@ class UnitWorkloadState(StrEnum):
     """Cassandra is active and ready."""
 
 
+class AuthRepairState(StrEnum):
+    """TODO."""
+
+    UNPLANNED = ""
+    PENDING = "pending"
+    WAITING_FOR_REPAIR = "waiting_for_repair"
+
+
 class RelationState:
     """Basic class for relation bag mapping classes."""
 
@@ -563,13 +571,14 @@ class ClusterContext(RelationState):
         self._field_setter_wrapper("operator-password", value)
 
     @property
-    def auth_repairing(self) -> bool:
+    def auth_repair(self) -> AuthRepairState:
         """TODO."""
-        return bool(self.relation_data.get("auth-repairing", ""))
+        return self.relation_data.get("auth-repair", AuthRepairState.UNPLANNED)
 
-    @auth_repairing.setter
-    def auth_repairing(self, value: bool) -> None:
-        self._field_setter_wrapper("auth-repairing", str(value))
+    @auth_repair.setter
+    def auth_repair(self, value: AuthRepairState) -> None:
+        """TODO."""
+        self._field_setter_wrapper("auth-repair", value.value)
 
 
 class ApplicationState(Object):

--- a/src/core/statuses.py
+++ b/src/core/statuses.py
@@ -23,3 +23,4 @@ class Status(Enum):
     WAITING_FOR_TLS = WaitingStatus("waiting for TLS setup")
     ROTATING_PEER_TLS = MaintenanceStatus("waiting for peer tls rotation to complete")
     ROTATING_CLIENT_TLS = MaintenanceStatus("waiting for client tls rotation to complete")
+    UPDATING_AUTH_RF = MaintenanceStatus("UPDATING_AUTH_RF")

--- a/src/core/statuses.py
+++ b/src/core/statuses.py
@@ -23,3 +23,4 @@ class Status(Enum):
     WAITING_FOR_TLS = WaitingStatus("waiting for TLS setup")
     ROTATING_PEER_TLS = MaintenanceStatus("waiting for peer tls rotation to complete")
     ROTATING_CLIENT_TLS = MaintenanceStatus("waiting for client tls rotation to complete")
+    REPAIRING_AUTH = MaintenanceStatus("repairing system_auth keyspace")

--- a/src/core/statuses.py
+++ b/src/core/statuses.py
@@ -23,4 +23,3 @@ class Status(Enum):
     WAITING_FOR_TLS = WaitingStatus("waiting for TLS setup")
     ROTATING_PEER_TLS = MaintenanceStatus("waiting for peer tls rotation to complete")
     ROTATING_CLIENT_TLS = MaintenanceStatus("waiting for client tls rotation to complete")
-    UPDATING_AUTH_RF = MaintenanceStatus("UPDATING_AUTH_RF")

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -374,9 +374,6 @@ class CassandraEvents(Object):
         if self.state.unit.workload_state == UnitWorkloadState.CANT_START:
             event.add_status(Status.CANT_START.value)
 
-        if self.state.unit.update_auth_rf_ongoing:
-            event.add_status(Status.UPDATING_AUTH_RF.value)
-
         event.add_status(Status.ACTIVE.value)
 
     def _collect_unit_tls_status(self, event: CollectStatusEvent) -> None:
@@ -462,7 +459,6 @@ class CassandraEvents(Object):
         logger.info("Hook for storage-detaching event completed")
 
     def _on_update_auth_rf(self, event: EventBase) -> None:
-        self.state.unit.update_auth_rf_ongoing = True
         if not self.state.unit.is_operational:
             logger.debug("Deferring on_peer_relation_departed due to unit not being operational")
             event.defer()
@@ -471,4 +467,3 @@ class CassandraEvents(Object):
             event.defer()
             return
         self.database_manager.update_system_auth_replication_factor(min(n, 3))
-        self.state.unit.update_auth_rf_ongoing = False

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -374,6 +374,9 @@ class CassandraEvents(Object):
         if self.state.unit.workload_state == UnitWorkloadState.CANT_START:
             event.add_status(Status.CANT_START.value)
 
+        if self.state.unit.update_auth_rf_ongoing:
+            event.add_status(Status.UPDATING_AUTH_RF.value)
+
         event.add_status(Status.ACTIVE.value)
 
     def _collect_unit_tls_status(self, event: CollectStatusEvent) -> None:
@@ -459,6 +462,7 @@ class CassandraEvents(Object):
         logger.info("Hook for storage-detaching event completed")
 
     def _on_update_auth_rf(self, event: EventBase) -> None:
+        self.state.unit.update_auth_rf_ongoing = True
         if not self.state.unit.is_operational:
             logger.debug("Deferring on_peer_relation_departed due to unit not being operational")
             event.defer()
@@ -467,3 +471,4 @@ class CassandraEvents(Object):
             event.defer()
             return
         self.database_manager.update_system_auth_replication_factor(min(n, 3))
+        self.state.unit.update_auth_rf_ongoing = False

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -11,11 +11,13 @@ from charms.data_platform_libs.v1.data_models import TypedCharmBase
 from ops import (
     CollectStatusEvent,
     ConfigChangedEvent,
+    EventBase,
     InstallEvent,
     LeaderElectedEvent,
     Object,
     RelationChangedEvent,
     RelationDepartedEvent,
+    RelationJoinedEvent,
     SecretChangedEvent,
     StartEvent,
     StorageDetachingEvent,
@@ -71,10 +73,16 @@ class CassandraEvents(Object):
         self.read_auth_secret = read_auth_secret
         self.restart = restart
 
+        self.charm.on.define_event("update_auth_rf", EventBase)
+        self.framework.observe(self.charm.on.update_auth_rf, self._on_update_auth_rf)
+
         self.framework.observe(self.charm.on.start, self._on_start)
         self.framework.observe(self.charm.on.install, self._on_install)
         self.framework.observe(self.charm.on.config_changed, self._on_config_changed)
         self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
+        self.framework.observe(
+            self.charm.on[PEER_RELATION].relation_joined, self._on_peer_relation_joined
+        )
         self.framework.observe(
             self.charm.on[PEER_RELATION].relation_changed, self._on_peer_relation_changed
         )
@@ -270,6 +278,11 @@ class CassandraEvents(Object):
             logger.error(f"Secret haven't passed validation: {e}")
             return
 
+    def _on_peer_relation_joined(self, event: RelationJoinedEvent) -> None:
+        if event.unit == self.charm.unit or not self.charm.unit.is_leader():
+            return
+        self.charm.on.update_auth_rf.emit()
+
     def _on_peer_relation_changed(self, event: RelationChangedEvent) -> None:
         if not self.state.unit.is_ready:
             logger.debug("Exiting on_peer_relation_changed due to unit not being ready")
@@ -296,6 +309,7 @@ class CassandraEvents(Object):
                 event.defer()
                 return
             self._recover_seeds()
+            self.charm.on.update_auth_rf.emit()
 
     def _on_leader_elected(self, event: LeaderElectedEvent) -> None:
         if not self.state.unit.is_ready:
@@ -306,6 +320,7 @@ class CassandraEvents(Object):
             event.defer()
             return
         self._recover_seeds()
+        self.charm.on.update_auth_rf.emit()
 
     def _on_update_status(self, _: UpdateStatusEvent) -> None:
         if self.state.unit.is_operational and not self.workload.is_alive():
@@ -435,3 +450,13 @@ class CassandraEvents(Object):
             raise e
 
         logger.info("Hook for storage-detaching event completed")
+
+    def _on_update_auth_rf(self, event: EventBase) -> None:
+        if not self.state.unit.is_operational:
+            logger.debug("Deferring on_peer_relation_departed due to unit not being operational")
+            event.defer()
+            return
+        if (n := self.node_manager.active_cluster_nodes_count) != self.charm.app.planned_units():
+            event.defer()
+            return
+        self.database_manager.update_system_auth_replication_factor(min(n, 3))

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -442,6 +442,13 @@ class CassandraEvents(Object):
                    The charm may be in a broken, unrecoverable state"""
             )
 
+        if self.charm.app.planned_units() == 1:
+            logger.info("Updating system_auth replication factor to 1 accordingly")
+            try:
+                self.database_manager.update_system_auth_replication_factor(1)
+            except Exception as e:
+                logger.error(f"Failed to update system_auth replication factor: {e}")
+
         logger.info(f"Starting unit {self.state.unit.unit_name} node decommissioning")
         try:
             self.node_manager.decommission()

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -296,12 +296,34 @@ class CassandraEvents(Object):
         if self.config_manager.render_cassandra_config():
             self.restart()
 
+        if (
+            self.charm.unit.is_leader()
+            and self.state.cluster.auth_repairing
+            and all(unit.auth_repaired for unit in self.state.units)
+        ):
+            self.state.cluster.auth_repairing = False
+            self.state.unit.auth_repaired = False
+
+        if not self.charm.unit.is_leader():
+            if not self.state.unit.auth_repaired and self.state.cluster.auth_repairing:
+                if not self.state.unit.is_operational:
+                    logger.debug(
+                        "Deferring on_peer_relation_changed due to unit not being operational"
+                    )
+                    event.defer()
+                    return
+                self.node_manager.repair_auth()
+            self.state.unit.auth_repaired = self.state.cluster.auth_repairing
+
     def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
         if not self.state.unit.is_ready:
             logger.debug("Exiting on_peer_relation_departed due to unit not being ready")
             return
 
-        if event.departing_unit != self.charm.unit and self.charm.unit.is_leader():
+        if event.departing_unit == self.charm.unit:
+            return
+
+        if self.charm.unit.is_leader():
             if not self.state.unit.is_config_change_eligible:
                 logger.debug(
                     "Deferring on_peer_relation_departed due to unit not being ready change config"
@@ -467,3 +489,6 @@ class CassandraEvents(Object):
             event.defer()
             return
         self.database_manager.update_system_auth_replication_factor(min(n, 3))
+        self.state.cluster.auth_repairing = True
+        self.node_manager.repair_auth()
+        self.state.unit.auth_repaired = True

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -249,6 +249,7 @@ class ConfigManager:
         return {
             "allocate_tokens_for_local_replication_factor": 3,
             "authorizer": "CassandraAuthorizer",
+            "auth_read_consistency_level": "LOCAL_ONE",
             "cas_contention_timeout": "1000ms",
             "cidr_authorizer": {"class_name": "AllowAllCIDRAuthorizer"},
             "commitlog_sync": "periodic",

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -279,6 +279,6 @@ class ConfigManager:
                 "cached_rows_warn_threshold": 2000,
             },
             "role_manager": "CassandraRoleManager",
-            "storage_compatibility_mode": "CASSANDRA_4",
+            "storage_compatibility_mode": "NONE",
             "storage_port": 7000,
         }

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -249,7 +249,6 @@ class ConfigManager:
         return {
             "allocate_tokens_for_local_replication_factor": 3,
             "authorizer": "CassandraAuthorizer",
-            "auth_read_consistency_level": "LOCAL_ONE",
             "cas_contention_timeout": "1000ms",
             "cidr_authorizer": {"class_name": "AllowAllCIDRAuthorizer"},
             "commitlog_sync": "periodic",

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -253,6 +253,14 @@ class DatabaseManager:
             raise ValueError(f"Invalid CQL identifier: {name}")
         return name
 
+    def update_system_auth_replication_factor(self, replication_factor: int) -> None:
+        """Update replication factor of system_auth keyspace."""
+        with self._session() as session:
+            session.execute(
+                "ALTER KEYSPACE system_auth WITH replication = "
+                f"{{'class': 'SimpleStrategy', 'replication_factor': {replication_factor}}}"
+            )
+
     @contextmanager
     def _session(
         self,

--- a/src/managers/node.py
+++ b/src/managers/node.py
@@ -111,7 +111,7 @@ class NodeManager:
             return 0
 
     def repair_auth(self) -> None:
-        """TODO."""
+        """Run full repair on system_auth keyspace."""
         self._workload.exec([_NODETOOL, "repair", "system_auth", "--full"])
 
     def _is_in_cluster(self, ip: str) -> bool:

--- a/src/managers/node.py
+++ b/src/managers/node.py
@@ -101,6 +101,15 @@ class NodeManager:
         """Disconnect node from the cluster using nodetool decommission command."""
         self._workload.exec([_NODETOOL, "decommission", "-f"])
 
+    @property
+    def active_cluster_nodes_count(self) -> int:
+        """Number of an active cluster nodes."""
+        try:
+            stdout, _ = self._workload.exec([_NODETOOL, "status"], suppress_error_log=True)
+            return stdout.count("UN  ")
+        except ExecError:
+            return 0
+
     def _is_in_cluster(self, ip: str) -> bool:
         if not ip:
             return False

--- a/src/managers/node.py
+++ b/src/managers/node.py
@@ -110,6 +110,10 @@ class NodeManager:
         except ExecError:
             return 0
 
+    def repair_auth(self) -> None:
+        """TODO."""
+        self._workload.exec([_NODETOOL, "repair", "system_auth", "--full"])
+
     def _is_in_cluster(self, ip: str) -> bool:
         if not ip:
             return False

--- a/tests/integration/helpers/cassandra.py
+++ b/tests/integration/helpers/cassandra.py
@@ -64,7 +64,7 @@ def connect_cql(
         logger.info("SSL context is disabled")
         ssl_context = None
 
-    for attempt in Retrying(wait=wait_fixed(2), stop=stop_after_delay(120), reraise=True):
+    for attempt in Retrying(wait=wait_fixed(10), stop=stop_after_delay(300), reraise=True):
         with attempt:
             cluster = Cluster(
                 auth_provider=auth_provider,

--- a/tests/integration/helpers/cassandra.py
+++ b/tests/integration/helpers/cassandra.py
@@ -64,7 +64,7 @@ def connect_cql(
         logger.info("SSL context is disabled")
         ssl_context = None
 
-    for attempt in Retrying(wait=wait_fixed(10), stop=stop_after_delay(300), reraise=True):
+    for attempt in Retrying(wait=wait_fixed(10), stop=stop_after_delay(600), reraise=True):
         with attempt:
             cluster = Cluster(
                 auth_provider=auth_provider,


### PR DESCRIPTION
# Issue
Currently, Cassandra cluster deploys with a `system_auth` keyspace replication factor set to 1. It means that only single copy of all of the authentication system data is stored across the cluster. And it leads to the availability issues because authentication data can be easily corrupted (or inconsistencies occur) during scaling down & HA scenarios. Those issues already affect our integration testing.

# Overview
This PR:
- extends state with `AuthRepairState`, `ClusterContext.auth_repair`, `UnitContext.auth_repaired`;
- adds `update_auth_rf` custom event logic in CassandraEvents to handle `system_auth` keyspace replication factor scaling & repair.

# Notes
Scaling of system_auth rf was moved into distinct event due to specific conditions in which replication factor of keyspace can be changed: unit should be operational and no token movements (bootstrapping / decommissioning of the unit) should be ongoing.
While replication factor scaling on it's own can provide sufficient redundancy to partially avoid availability issues, full repair of this keyspace is required by-design to completely avoid `bad credentials` & `bad metadata detected` errors due to this keyspace inconsistency errors.