### PR TITLE
[MISC] General improvement for how-to docs

### DIFF
--- a/docs/how-to/encryption.md
+++ b/docs/how-to/encryption.md
@@ -84,7 +84,7 @@ This confirms that Apache Cassandra requires a secure TLS connection.
 Fetch the root CA from the self-signed certificate operator:
 
 ```shell
-juju run ssc/0 get-ca-certificate --format yaml | yq '.ssc/0.results.ca-certificate' > ca.cert
+juju run <tls-certificates>/0 get-ca-certificate --format yaml | yq '.<tls-certificates>/0.results.ca-certificate' > ca.cert
 ```
 
 The CA needs to be used to verify the certificate provided by the Apache Cassandra servers in the TLS handshake. 

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -16,7 +16,7 @@ can be used, and this step is shown in the COS tutorial.
 
 ### Offer interfaces via the COS controller
 
-Switch to COS K8s environment and offer COS interfaces to be cross-model related with Charmed Apache Kafka VM model:
+Switch to COS K8s environment and offer COS interfaces to be cross-model related with Charmed Apache Cassandra VM model:
 
 ```shell
 juju switch <k8s_controller>:<cos_model_name>
@@ -154,4 +154,4 @@ Point the corresponding `*_path` configuration options to these files (or their 
 
 ### Conclusion
 
-In this guide, we enabled monitoring on a Charmed Apache Kafka deployment and integrated alert rules and dashboards by syncing a git repository to the COS stack.
+In this guide, we enabled monitoring on a Charmed Apache Cassandra deployment and integrated alert rules and dashboards by syncing a git repository to the COS stack.


### PR DESCRIPTION
I have mostly improved the TLS guide to provide a bit more "charming" experience using actions, and using the `CA` certificate which is more conceptually correct, instead of the single client certificates. I have tested this and it works as expected. I also provided a bit more instruction to use the `charmed-cassandra` snap that we provide as part of the solution, also to connect as clients. 

I have also applied the usual convention of referring to "Apache <product>" and fixed a couple of typos coming from the Kafka documentation