### PR TITLE
[DPE-8634] Fix сassandra getting stuck when scaling up with TLS

### DIFF
--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -193,6 +193,7 @@ class CassandraEvents(Object):
             return
 
         if not self._are_seeds_reachable:
+            self.state.unit.workload_state = UnitWorkloadState.WAITING_FOR_START            
             logger.debug("Deferring subordinate on_start due to seeds not being ready")
             event.defer()
             return

--- a/src/events/cassandra.py
+++ b/src/events/cassandra.py
@@ -193,7 +193,7 @@ class CassandraEvents(Object):
             return
 
         if not self._are_seeds_reachable:
-            self.state.unit.workload_state = UnitWorkloadState.WAITING_FOR_START            
+            self.state.unit.workload_state = UnitWorkloadState.WAITING_FOR_START
             logger.debug("Deferring subordinate on_start due to seeds not being ready")
             event.defer()
             return

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -160,9 +160,8 @@ def test_enable_client_self_signed_tls(
 
     assert client_ca_2
 
-def test_scale_up_with_tls(
-    juju: jubilant.Juju, app_name: str
-) -> None:
+
+def test_scale_up_with_tls(juju: jubilant.Juju, app_name: str) -> None:
     juju.add_unit(app_name)
 
     # Wait for peer_certs and client_certs rotation for new unit
@@ -176,31 +175,31 @@ def test_scale_up_with_tls(
     units = get_unit_names(juju, app_name)
 
     peer_ca_list = []
-    client_ca_list = []    
+    client_ca_list = []
 
     for unit in units:
-       client_ca = unit_secret_extract(
-           juju,
-           unit_name=unit,
-           secret_name=CLIENT_CA_CERT,
-       )
-   
-       assert client_ca
-       client_ca_list.append(client_ca)
-   
-       peer_ca = unit_secret_extract(
-           juju,
-           unit_name=unit,
-           secret_name=PEER_CA_CERT,
-       )
-   
-       assert peer_ca
-       peer_ca_list.append(peer_ca)
+        client_ca = unit_secret_extract(
+            juju,
+            unit_name=unit,
+            secret_name=CLIENT_CA_CERT,
+        )
 
+        assert client_ca
+        client_ca_list.append(client_ca)
+
+        peer_ca = unit_secret_extract(
+            juju,
+            unit_name=unit,
+            secret_name=PEER_CA_CERT,
+        )
+
+        assert peer_ca
+        peer_ca_list.append(peer_ca)
 
     assert len(set(peer_ca_list)) == 1, "peer certificates differ"
-    assert len(set(client_ca_list)) == 1, "client certificates differ"    
-       
+    assert len(set(client_ca_list)) == 1, "client certificates differ"
+
+
 def test_disable_peer_self_signed_tls(
     juju: jubilant.Juju, app_name: str, charm_versions: IntegrationTestsCharms
 ) -> None:


### PR DESCRIPTION
Fix an issue where Cassandra units would get stuck in the installing state when scaling up with TLS enabled.

Previously, when a new unit was added after TLS had been enabled, it could not successfully start because:

The new unit could not connect to the seed nodes (TLS handshake failed).
The charm deferred the certificate-available event indefinitely since the workload state was still `INSTALLING`.
As a result, the unit never updated its certificates nor completed the startup phase.

This change ensures that if the seeds are not yet reachable, the unit transitions to a `WAITING_FOR_START` state instead of remaining in `INSTALLING`.
This allows the charm to correctly defer and later handle the certificate-available event once the cluster becomes reachable.

Also, added new integration test, to specifically check this scenario.