### PR TITLE
[DPE-8598] Refactor cql_connect in integration tests

### DIFF
--- a/tests/integration/helpers/continuous_writes.py
+++ b/tests/integration/helpers/continuous_writes.py
@@ -39,6 +39,9 @@ class ContinuousWrites:
             and not self.write_event.is_set()
         )
 
+        self.hosts = hosts
+        self.password = password
+
         self._init_keyspace(replication_factor)
         self.process = Process(
             target=self._continuous_writes,
@@ -46,6 +49,7 @@ class ContinuousWrites:
                 self.stop_event,
                 self.write_event,
                 hosts,
+                password,
                 self.keyspace_name,
                 self.timeout,
             ),

--- a/tests/integration/helpers/continuous_writes.py
+++ b/tests/integration/helpers/continuous_writes.py
@@ -5,7 +5,6 @@
 import logging
 from multiprocessing import Event, Process, synchronize
 
-import jubilant
 from cassandra.cluster import ResultSet
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
@@ -21,29 +20,31 @@ class ContinuousWrites:
         self.force_timeout = timeout * 2
         self.stop_event = Event()
         self.write_event = Event()
-        self.juju: jubilant.Juju | None = None
-        self.app_name: str | None = None
+        self.hosts: list[str] | None = None
+        self.password: str | None = None
         self.process: Process | None = None
 
     def start(
         self,
-        juju: jubilant.Juju,
-        app_name: str,
         hosts: list[str] | None = None,
+        password: str | None = None,
         replication_factor: int = 1,
     ) -> None:
-        assert not self.juju
+        assert password
+        assert (
+            not self.hosts
+            and not self.password
+            and not self.process
+            and not self.stop_event.is_set()
+            and not self.write_event.is_set()
+        )
 
-        self.juju = juju
-        self.app_name = app_name
         self._init_keyspace(replication_factor)
         self.process = Process(
             target=self._continuous_writes,
             args=(
                 self.stop_event,
                 self.write_event,
-                juju,
-                app_name,
                 hosts,
                 self.keyspace_name,
                 self.timeout,
@@ -53,7 +54,7 @@ class ContinuousWrites:
         self.write_event.wait(self.force_timeout)
 
     def stop_and_assert_writes(self, hosts: list[str] | None = None) -> None:
-        assert self.juju and self.app_name and self.process and self.process.is_alive()
+        assert self.process and self.process.is_alive()
 
         self.assert_new_writes(hosts)
 
@@ -76,7 +77,7 @@ class ContinuousWrites:
             self.process.terminate()
 
     def assert_new_writes(self, hosts: list[str] | None = None) -> None:
-        assert self.juju and self.app_name and self.process and self.process.is_alive()
+        assert self.process and self.process.is_alive()
 
         position = self._get_max_position(hosts)
 
@@ -87,14 +88,17 @@ class ContinuousWrites:
 
         assert next_position > position
 
+        self._assert_writes(hosts)
+
     def _init_keyspace(self, replication_factor: int) -> None:
-        assert self.juju and self.app_name
+        assert self.hosts and self.password
+
         for attempt in Retrying(
             wait=wait_fixed(10), stop=stop_after_delay(self.timeout), reraise=True
         ):
             with attempt:
                 with connect_cql(
-                    juju=self.juju, app_name=self.app_name, timeout=self.timeout
+                    hosts=self.hosts, password=self.password, timeout=self.timeout
                 ) as session:
                     session.execute(
                         f"CREATE KEYSPACE {self.keyspace_name} WITH replication = "
@@ -126,16 +130,15 @@ class ContinuousWrites:
                 assert pcount == (1 + pmax - pmin)
 
     def _cql_exec(self, query: str, hosts: list[str] | None = None) -> ResultSet | None:
-        assert self.juju and self.app_name
+        assert self.hosts and self.password
 
         for attempt in Retrying(
             wait=wait_fixed(10), stop=stop_after_delay(self.timeout), reraise=True
         ):
             with attempt:
                 with connect_cql(
-                    juju=self.juju,
-                    app_name=self.app_name,
-                    hosts=hosts,
+                    hosts=hosts or self.hosts,
+                    password=self.password,
                     keyspace=self.keyspace_name,
                     timeout=self.timeout,
                 ) as session:
@@ -147,9 +150,8 @@ class ContinuousWrites:
     def _continuous_writes(
         stop_event: synchronize.Event,
         write_event: synchronize.Event,
-        juju: jubilant.Juju,
-        app_name: str,
-        hosts: list[str] | None,
+        hosts: list[str],
+        password: str,
         keyspace_name: str,
         timeout: int,
     ) -> None:
@@ -157,9 +159,8 @@ class ContinuousWrites:
         for attempt in Retrying(wait=wait_fixed(10), stop=stop_after_delay(timeout), reraise=True):
             with attempt:
                 with connect_cql(
-                    juju=juju,
-                    app_name=app_name,
                     hosts=hosts,
+                    password=password,
                     keyspace=keyspace_name,
                     timeout=timeout,
                 ) as session:

--- a/tests/integration/helpers/continuous_writes.py
+++ b/tests/integration/helpers/continuous_writes.py
@@ -73,8 +73,9 @@ class ContinuousWrites:
         self._clear_keyspace()
         self.stop_event.clear()
         self.write_event.clear()
-        self.juju = None
-        self.app_name = None
+        self.hosts = None
+        self.password = None
+        self.process = None
 
     def force_stop(self) -> None:
         if self.process and self.process.is_alive():

--- a/tests/integration/helpers/juju.py
+++ b/tests/integration/helpers/juju.py
@@ -81,10 +81,11 @@ def get_secrets_by_label(juju: jubilant.Juju, label: str, owner: str) -> list[di
     return secret_data_list
 
 
-def get_unit_address(juju: jubilant.Juju, app_name: str, unit_num) -> str:
-    """Get the address for a units."""
+def get_unit_address(juju: jubilant.Juju, app_name: str, unit: str | int) -> str:
+    """Get the address for a unit."""
+    unit = unit if (isinstance(unit, str) and app_name in unit) else f"{app_name}/{unit}"
     status = juju.status()
-    address = status.apps[app_name].units[f"{app_name}/{unit_num}"].public_address
+    address = status.apps[app_name].units[unit].public_address
     return address
 
 
@@ -304,7 +305,7 @@ def get_hosts(juju: jubilant.Juju, app_name: str, unit_name: str = "") -> list[s
     return [u.public_address for u in units.values()]
 
 
-def get_leader_unit(juju, app_name: str) -> tuple[str, UnitStatus]:
+def get_leader_unit(juju: jubilant.Juju, app_name: str) -> tuple[str, UnitStatus]:
     """Return the name of the leader unit for the given application.
 
     Raises:
@@ -317,7 +318,7 @@ def get_leader_unit(juju, app_name: str) -> tuple[str, UnitStatus]:
     raise ValueError(f"No leader unit found for application '{app_name}'")
 
 
-def get_non_leader_units(juju, app_name: str) -> list[str]:
+def get_non_leader_units(juju: jubilant.Juju, app_name: str) -> list[str]:
     """Return a list of all non-leader units for the given application."""
     app = juju.status().apps[app_name]
     return [name for name, unit in app.units.items() if not unit.leader]

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -6,9 +6,12 @@ import logging
 from pathlib import Path
 
 import jubilant
-from cassandra.cluster import ResultSet
 
-from integration.helpers.cassandra import connect_cql
+from integration.helpers.cassandra import (
+    OPERATOR_PASSWORD,
+)
+from integration.helpers.continuous_writes import ContinuousWrites
+from integration.helpers.juju import app_secret_extract, get_hosts
 
 logger = logging.getLogger(__name__)
 
@@ -22,61 +25,30 @@ def test_deploy_bad_config(juju: jubilant.Juju, cassandra_charm: Path, app_name:
     juju.wait(jubilant.all_blocked)
 
 
-def test_deploy_resolve_config(juju: jubilant.Juju, app_name: str) -> None:
+def test_deploy_resolve_config(
+    juju: jubilant.Juju, app_name: str, continuous_writes: ContinuousWrites
+) -> None:
     juju.config(app_name, values={"profile": "testing"})
     juju.wait(jubilant.all_active)
 
-
-def test_write(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], timeout=300) as session:
-        session.execute(
-            "CREATE KEYSPACE test "
-            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}",
-        )
-        session.set_keyspace("test")
-        session.execute("CREATE TABLE test(message TEXT PRIMARY KEY)")
-        session.execute("INSERT INTO test(message) VALUES ('hello')")
+    continuous_writes.start(
+        get_hosts(juju, app_name), app_secret_extract(juju, app_name, OPERATOR_PASSWORD)
+    )
 
 
-def test_read(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test")
-        assert (
-            isinstance(res, ResultSet)
-            and len(res_list := res.all()) == 1
-            and res_list[0].message == "hello"
-        ), "test data written prior aren't found"
-
-
-def test_bad_config(juju: jubilant.Juju, app_name: str) -> None:
+def test_bad_config(
+    juju: jubilant.Juju, app_name: str, continuous_writes: ContinuousWrites
+) -> None:
     juju.config(app_name, values={"profile": "bad_value"})
     juju.wait(jubilant.all_blocked)
 
-
-def test_read_bad_config(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test")
-        assert (
-            isinstance(res, ResultSet)
-            and len(res_list := res.all()) == 1
-            and res_list[0].message == "hello"
-        ), "test data written prior aren't found"
+    continuous_writes.assert_new_writes()
 
 
-def test_resolve_config(juju: jubilant.Juju, app_name: str) -> None:
+def test_resolve_config(
+    juju: jubilant.Juju, app_name: str, continuous_writes: ContinuousWrites
+) -> None:
     juju.config(app_name, values={"profile": "testing"})
     juju.wait(jubilant.all_active)
 
-
-def test_read_after_resolve(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test")
-        assert (
-            isinstance(res, ResultSet)
-            and len(res_list := res.all()) == 1
-            and res_list[0].message == "hello"
-        ), "test data written prior aren't found"
+    continuous_writes.stop_and_assert_writes()

--- a/tests/integration/test_multinode.py
+++ b/tests/integration/test_multinode.py
@@ -37,7 +37,8 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
 def test_write_primary_read_secondary(juju: jubilant.Juju, app_name: str) -> None:
     password = app_secret_extract(juju, app_name, OPERATOR_PASSWORD)
 
-    leader_hosts = [get_unit_address(juju, app_name, get_leader_unit(juju, app_name))]
+    leader, _ = get_leader_unit(juju, app_name)
+    leader_hosts = [get_unit_address(juju, app_name, leader)]
     prepare_keyspace_and_table(leader_hosts, password=password)
     wrote = write_n_rows(hosts=leader_hosts, password=password)
 

--- a/tests/integration/test_multinode.py
+++ b/tests/integration/test_multinode.py
@@ -6,9 +6,20 @@ import logging
 from pathlib import Path
 
 import jubilant
-from cassandra.cluster import ResultSet
 
-from integration.helpers.cassandra import connect_cql
+from integration.helpers.cassandra import (
+    OPERATOR_PASSWORD,
+    assert_rows,
+    prepare_keyspace_and_table,
+    read_n_rows,
+    write_n_rows,
+)
+from integration.helpers.juju import (
+    app_secret_extract,
+    get_leader_unit,
+    get_non_leader_units,
+    get_unit_address,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -23,24 +34,21 @@ def test_deploy(juju: jubilant.Juju, cassandra_charm: Path, app_name: str) -> No
     juju.wait(jubilant.all_active, timeout=1000)
 
 
-def test_write(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/0"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], timeout=300) as session:
-        session.execute(
-            "CREATE KEYSPACE test "
-            "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}",
-        )
-        session.set_keyspace("test")
-        session.execute("CREATE TABLE test(message TEXT PRIMARY KEY)")
-        session.execute("INSERT INTO test(message) VALUES ('hello')")
+def test_write_primary_read_secondary(juju: jubilant.Juju, app_name: str) -> None:
+    password = app_secret_extract(juju, app_name, OPERATOR_PASSWORD)
 
+    leader_hosts = [get_unit_address(juju, app_name, get_leader_unit(juju, app_name))]
+    prepare_keyspace_and_table(leader_hosts, password=password)
+    wrote = write_n_rows(hosts=leader_hosts, password=password)
 
-def test_read(juju: jubilant.Juju, app_name: str) -> None:
-    host = juju.status().apps[app_name].units[f"{app_name}/2"].public_address
-    with connect_cql(juju=juju, app_name=app_name, hosts=[host], keyspace="test") as session:
-        res = session.execute("SELECT message FROM test", timeout=300)
-        assert (
-            isinstance(res, ResultSet)
-            and len(res_list := res.all()) == 1
-            and res_list[0].message == "hello"
-        ), "test data written prior aren't found"
+    got1 = read_n_rows(
+        hosts=[get_unit_address(juju, app_name, get_non_leader_units(juju, app_name)[0])],
+        password=password,
+    )
+    assert_rows(wrote, got1)
+
+    got2 = read_n_rows(
+        hosts=[get_unit_address(juju, app_name, get_non_leader_units(juju, app_name)[1])],
+        password=password,
+    )
+    assert_rows(wrote, got2)

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -98,6 +98,8 @@ def test_single_node_scale_down(
 
 
 def test_single_node_scale_down_scale_up(juju: jubilant.Juju, app_name: str) -> None:
+    scale_sequentially_to(juju, app_name, 2)
+
     non_leader_units = [
         name for name, unit in juju.status().apps[app_name].units.items() if not unit.leader
     ]

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -55,8 +55,8 @@ def test_default_tls(juju: jubilant.Juju, app_name: str) -> None:
     num_unit = 0
 
     unit_addreses = [
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/0")[0],
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/1")[0],
+        get_unit_address(juju=juju, app_name=app_name, unit=0),
+        get_unit_address(juju=juju, app_name=app_name, unit=1),
     ]
 
     peer_ca = unit_secret_extract(
@@ -83,8 +83,8 @@ def test_enable_peer_self_signed_tls(
     num_unit = 0
 
     unit_addreses = [
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/0")[0],
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/1")[0],
+        get_unit_address(juju=juju, app_name=app_name, unit=0),
+        get_unit_address(juju=juju, app_name=app_name, unit=1),
     ]
 
     peer_ca_1 = unit_secret_extract(
@@ -132,8 +132,8 @@ def test_enable_client_self_signed_tls(
     num_unit = 0
 
     unit_addreses = [
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/0")[0],
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/1")[0],
+        get_unit_address(juju=juju, app_name=app_name, unit=0),
+        get_unit_address(juju=juju, app_name=app_name, unit=1),
     ]
 
     juju.integrate(f"{charm_versions.tls.app}:certificates", f"{app_name}:client-certificates")
@@ -207,8 +207,8 @@ def test_disable_peer_self_signed_tls(
     num_unit = 0
 
     unit_addreses = [
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/0")[0],
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/1")[0],
+        get_unit_address(juju=juju, app_name=app_name, unit=0),
+        get_unit_address(juju=juju, app_name=app_name, unit=1),
     ]
 
     logger.info("[test_disable_peer_self_signed_tls] Get peer ca 1")
@@ -256,8 +256,8 @@ def test_disable_client_self_signed_tls(
     num_unit = 0
 
     unit_addreses = [
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/0")[0],
-        get_hosts(juju=juju, app_name=app_name, unit_name=f"{app_name}/1")[0],
+        get_unit_address(juju=juju, app_name=app_name, unit=0),
+        get_unit_address(juju=juju, app_name=app_name, unit=1),
     ]
 
     juju.remove_relation(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -10,7 +10,7 @@ import jubilant
 from integration.helpers.cassandra import check_tls
 from integration.helpers.juju import (
     check_node_is_up,
-    get_hosts,
+    get_unit_address,
     get_unit_names,
     unit_secret_extract,
 )


### PR DESCRIPTION
Due to [previous discussion](https://github.com/canonical/cassandra-operator/pull/23#discussion_r2438639062): Cassandra integration tests helpers were refactored to not have direct Juju access and instead require explicit `hosts` & `password` parameters.