### PR TITLE
[DPE-8883] Handle forceful unit removals

### DIFF
--- a/src/managers/node.py
+++ b/src/managers/node.py
@@ -14,7 +14,7 @@ from core.workload import WorkloadBase
 
 logger = logging.getLogger(__name__)
 
-_NODETOOL = "charmed-cassandra.nodetool"
+NODETOOL = "charmed-cassandra.nodetool"
 
 
 @dataclass
@@ -46,7 +46,7 @@ class NodeManager:
     def is_bootstrap_pending(self) -> bool:
         """Whether `nodetool info` bootstrap state is NEEDS_BOOTSTRAP."""
         try:
-            stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
+            stdout, _ = self._workload.exec([NODETOOL, "info"], suppress_error_log=True)
             return "Bootstrap state        : NEEDS_BOOTSTRAP" in stdout
         except ExecError:
             return False
@@ -55,7 +55,7 @@ class NodeManager:
     def is_bootstrap_in_unknown_state(self) -> bool:
         """Whether `nodetool info` bootstrap state is not IN_PROGRESS or COMPLETED."""
         try:
-            stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
+            stdout, _ = self._workload.exec([NODETOOL, "info"], suppress_error_log=True)
             return (
                 "Bootstrap state        : IN_PROGRESS" not in stdout
                 and "Bootstrap state        : COMPLETED" not in stdout
@@ -67,11 +67,11 @@ class NodeManager:
     def is_bootstrap_decommissioning(self) -> bool:
         """Check if the node is in the process of, or has completed, decommissioning."""
         try:
-            stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
+            stdout, _ = self._workload.exec([NODETOOL, "info"], suppress_error_log=True)
             if "Bootstrap state        : DECOMMISSIONED" in stdout:
                 return True
 
-            stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
+            stdout, _ = self._workload.exec([NODETOOL, "info"], suppress_error_log=True)
             return "Decommissioning        : true" in stdout
 
         except ExecError:
@@ -89,18 +89,18 @@ class NodeManager:
             whether operation was successful.
         """
         try:
-            self._workload.exec([_NODETOOL, "bootstrap", "resume"])
+            self._workload.exec([NODETOOL, "bootstrap", "resume"])
             return True
         except ExecError:
             return False
 
     def prepare_shutdown(self) -> None:
         """Prepare Cassandra unit for safe shutdown using nodetool drain command."""
-        self._workload.exec([_NODETOOL, "drain"])
+        self._workload.exec([NODETOOL, "drain"])
 
     def decommission(self) -> None:
         """Disconnect node from the cluster using nodetool decommission command."""
-        self._workload.exec([_NODETOOL, "decommission", "-f"])
+        self._workload.exec([NODETOOL, "decommission", "-f"])
 
     def ensure_cluster_topology(self, nodes: int) -> bool:
         """Check stability & consistency of the cluster topology using nodetool status command.
@@ -109,7 +109,7 @@ class NodeManager:
             whether the cluster topology is stable and consistent with provided nodes count.
         """
         try:
-            stdout, _ = self._workload.exec([_NODETOOL, "status"], suppress_error_log=True)
+            stdout, _ = self._workload.exec([NODETOOL, "status"], suppress_error_log=True)
             if "DN  " in stdout:
                 return False
             return stdout.count("UN  ") == nodes
@@ -119,31 +119,33 @@ class NodeManager:
     def remove_bad_nodes(self, good_node_ips: list[str]) -> None:
         """Remove unknown nodes in down state using nodetool removenode command."""
         try:
-            status_stdout, _ = self._workload.exec([_NODETOOL, "status"])
+            status_stdout, _ = self._workload.exec([NODETOOL, "status"])
         except ExecError:
             return
 
-        down_nodes = re.findall(r"^DN  (\S+)(?:\s+\S+){4}\s+(\S+).+$", status_stdout, re.MULTILINE)
+        down_nodes = re.findall(
+            r"^DN  (\S+)\s+(?:\?|\S+\s+\S+)(?:\s+\S+){2}\s+(\S+).+$", status_stdout, re.MULTILINE
+        )
 
         for down_node in down_nodes:
             ip, host_id = down_node
             if ip in good_node_ips:
                 continue
             try:
-                self._workload.exec([_NODETOOL, "removenode", host_id])
+                self._workload.exec([NODETOOL, "removenode", host_id])
                 logger.info(f"Removed bad node {ip} from Cassandra cluster")
             except ExecError:
                 logger.error(f"Failed to remove bad node {ip} from Cassandra cluster")
 
     def repair_auth(self) -> None:
         """Run full repair on system_auth keyspace."""
-        self._workload.exec([_NODETOOL, "repair", "system_auth", "--full"])
+        self._workload.exec([NODETOOL, "repair", "system_auth", "--full"])
 
     def _is_in_cluster(self, ip: str) -> bool:
         if not ip:
             return False
         try:
-            stdout, _ = self._workload.exec([_NODETOOL, "status"], suppress_error_log=True)
+            stdout, _ = self._workload.exec([NODETOOL, "status"], suppress_error_log=True)
             return f"UN  {ip}" in stdout
         except ExecError:
             return False
@@ -151,7 +153,7 @@ class NodeManager:
     @property
     def _is_gossip_active(self) -> bool:
         try:
-            stdout, _ = self._workload.exec([_NODETOOL, "info"], suppress_error_log=True)
+            stdout, _ = self._workload.exec([NODETOOL, "info"], suppress_error_log=True)
             return "Gossip active          : true" in stdout
         except ExecError:
             return False
@@ -174,7 +176,7 @@ class NodeManager:
         { <IP>: GossipNode, ... }
         """
         try:
-            text, _ = self._workload.exec([_NODETOOL, "gossipinfo"], suppress_error_log=True)
+            text, _ = self._workload.exec([NODETOOL, "gossipinfo"], suppress_error_log=True)
         except ExecError:
             return {}
 

--- a/tests/unit/test_node_manager.py
+++ b/tests/unit/test_node_manager.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+
+from unittest.mock import MagicMock, call
+
+from managers.node import NODETOOL, NodeManager
+
+
+def test_remove_bad_nodes():
+    status_all_active = """Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address        Load        Tokens  Owns (effective)  Host ID                               Rack 
+UN  10.222.10.92   163.81 KiB  16      48.5%             0b731c0a-641f-4533-b8ad-5527ca96d1f5  rack1
+UN  10.222.10.254  195.76 KiB  16      48.8%             362fd8fd-169f-4949-bbc4-4a81d9aa92c6  rack1
+UN  10.222.10.113  194.71 KiB  16      50.7%             8f6406bd-96f5-43c3-9433-8439773b7495  rack1
+UN  10.222.10.5    96.45 KiB   16      52.0%             1a820086-663b-496f-87b7-d6ccf99df077  rack1"""  # noqa: E501 W291
+
+    status_one_active = """Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address        Load        Tokens  Owns (effective)  Host ID                               Rack 
+UN  10.222.10.92   210.03 KiB  16      48.5%             0b731c0a-641f-4533-b8ad-5527ca96d1f5  rack1
+DN  10.222.10.254  ?           16      48.8%             362fd8fd-169f-4949-bbc4-4a81d9aa92c6  rack1
+DN  10.222.10.113  ?           16      50.7%             8f6406bd-96f5-43c3-9433-8439773b7495  rack1
+DN  10.222.10.5    ?           16      52.0%             1a820086-663b-496f-87b7-d6ccf99df077  rack1"""  # noqa: E501 W291
+
+    status_one_removed = """Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address        Load        Tokens  Owns (effective)  Host ID                               Rack 
+UN  10.222.10.92   210.03 KiB  16      48.5%             0b731c0a-641f-4533-b8ad-5527ca96d1f5  rack1
+UN  10.222.10.254  233.69 KiB  16      48.8%             362fd8fd-169f-4949-bbc4-4a81d9aa92c6  rack1
+UN  10.222.10.113  246.63 KiB  16      50.7%             8f6406bd-96f5-43c3-9433-8439773b7495  rack1
+DN  10.222.10.5    148.26 KiB  16      52.0%             1a820086-663b-496f-87b7-d6ccf99df077  rack1"""  # noqa: E501 W291
+
+    workload = MagicMock(cassandra_paths=MagicMock(env=MagicMock()))
+    node_manager = NodeManager(workload=workload)
+
+    workload.exec.return_value = (status_all_active, None)
+    node_manager.remove_bad_nodes(good_node_ips=["10.222.10.92", "10.222.10.254"])
+    workload.exec.assert_called_once_with([NODETOOL, "status"])
+    workload.exec.reset_mock()
+
+    workload.exec.return_value = (status_one_active, None)
+    node_manager.remove_bad_nodes(good_node_ips=["10.222.10.92", "10.222.10.254"])
+    assert workload.exec.call_count == 3
+    workload.exec.assert_has_calls(
+        calls=[
+            call([NODETOOL, "status"]),
+            call([NODETOOL, "removenode", "8f6406bd-96f5-43c3-9433-8439773b7495"]),
+            call([NODETOOL, "removenode", "1a820086-663b-496f-87b7-d6ccf99df077"]),
+        ],
+        any_order=True,
+    )
+    workload.exec.reset_mock()
+
+    workload.exec.return_value = (status_one_removed, None)
+    node_manager.remove_bad_nodes(good_node_ips=["10.222.10.92", "10.222.10.254"])
+    assert workload.exec.call_count == 2
+    workload.exec.assert_has_calls(
+        calls=[
+            call([NODETOOL, "status"]),
+            call([NODETOOL, "removenode", "1a820086-663b-496f-87b7-d6ccf99df077"]),
+        ],
+        any_order=True,
+    )
+    workload.exec.reset_mock()


### PR DESCRIPTION
This PR introduces handling of forceful unit removal, after which already removed Juju units still persist in the Cassandra cluster. Check for dead unknown Cassandra nodes is added in the update status event hook utilizing `nodetool status` & `nodetool removenode` commands.