### PR TITLE
Improve bootstrapping logic

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -100,7 +100,6 @@ kill-timeout: 1h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
-  CONCIERGE_JUJU_CHANNEL/juju35: 3.5/stable
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/src/charm.py
+++ b/src/charm.py
@@ -130,6 +130,11 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
             self.bootstrap_manager.release()
             return
 
+        if self.node_manager.is_bootstrap_pending:
+            logger.debug("Deferring on_bootstrap due to pending bootstrap state")
+            event.defer()
+            return
+
         if not self.node_manager.is_healthy(ip=self.state.unit.ip):
             logger.debug("Deferring on_bootstrap due to workload not being healthy yet")
             event.defer()
@@ -154,15 +159,6 @@ class CassandraCharm(TypedCharmBase[CharmConfig]):
         if not self.workload.is_alive():
             logger.error("Cassandra service abruptly stopped during bootstrap")
             return False
-
-        if self.node_manager.is_bootstrap_pending:
-            logger.warning("Pending Cassandra bootstrap is detected, trying to resume")
-            if self.node_manager.resume_bootstrap():
-                logger.info("Cassandra bootstrap resuming successful")
-                return True
-            else:
-                logger.error("Cassandra bootstrap resuming failed")
-                return False
 
         if self.node_manager.is_bootstrap_in_unknown_state:
             logger.error("Cassandra bootstrap is in unknown state, failed bootstrap assumed")

--- a/src/managers/node.py
+++ b/src/managers/node.py
@@ -59,6 +59,7 @@ class NodeManager:
             return (
                 "Bootstrap state        : IN_PROGRESS" not in stdout
                 and "Bootstrap state        : COMPLETED" not in stdout
+                and "Bootstrap state        : NEEDS_BOOTSTRAP" not in stdout
             )
         except ExecError:
             return False
@@ -81,18 +82,6 @@ class NodeManager:
         """Get IP and hostname of this unit."""
         hostname = socket.gethostname()
         return socket.gethostbyname(hostname), hostname
-
-    def resume_bootstrap(self) -> bool:
-        """Resume Cassandra bootstrap.
-
-        Returns:
-            whether operation was successful.
-        """
-        try:
-            self._workload.exec([NODETOOL, "bootstrap", "resume"])
-            return True
-        except ExecError:
-            return False
 
     def prepare_shutdown(self) -> None:
         """Prepare Cassandra unit for safe shutdown using nodetool drain command."""


### PR DESCRIPTION
Currently, Cassandra charm tries to run `nodetool bootstrap resume` command when it encounters `Bootstrap state: NEEDS_BOOTSTRAP` state during unit bootstrap. Such process will fail with "bootstrap resume command disabled" error, although right decision in this case will be to just wait for it to automatically start Cassandra bootstrap process. This PR fixes this to make logic right and to avoid blocked status flakiness during cluster deployments.