### PR TITLE
Fix integration tests spread collection

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,19 +19,24 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up environment
         run: |
-          sudo snap install charmcraft --classic
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
         shell: python
         run: |
           import json
+          import pathlib
           import os
           import subprocess
 
           spread_jobs = (
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci"], capture_output=True, check=True, text=True
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
               )
               .stdout.strip()
               .split("\n")


### PR DESCRIPTION
Ported fix from [postgresql-operator](https://github.com/canonical/postgresql-operator/pull/1288#issue-3621579740):

> charmcraft 4.0 removed `--list` from the `charmcraft test` command Use spread directly instead
> 
> (charmcraft 3, when calling `charmcraft test --list`, called `spread -list`, so behavior should be the same [except maybe if spread snap is different version from spread that charmcraft 3 was using])
