### PR TITLE
chore: switch default profile to testing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@
 options:
   profile:
     type: string
-    default: production
+    default: testing
     description: |
       Profile represents the scope of deployment, and used to tune resource allocation.
       Allowed values are: `production` and `testing`.


### PR DESCRIPTION
Current default is "production" which will use half of all available memory. This is not right specially in the context of LXD, since memory constraints need a specific config to be set.