### PR TITLE
[DPE-9436] fix: build & CI issues

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -50,25 +50,10 @@ parts:
       - libssl-dev # Needed to build Python dependencies with Rust from source
       - pkg-config # Needed to build Python dependencies with Rust from source
       - libev-dev
+      - rustup
     override-build: |
-      # Workaround for https://github.com/canonical/charmcraft/issues/2068
-      # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
-      if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
-      then
-        snap install rustup --classic
-      else
-        apt-get install rustup -y
-      fi
-
-      # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
-      # archive—which means the rustup version could be updated at any time. Print rustup version
-      # to build log to make changes to the snap's rustup version easier to track
-      rustup --version
-
-      # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
-      # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.87.0  # renovate: charmcraft-rust-latest
+      rustup default 1.93.1
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -6,15 +6,6 @@ providers:
     enable: true
     bootstrap: true
     channel: 6/stable
-  microk8s:
-    enable: true
-    bootstrap: true
-    channel: 1.32-strict/stable
-    addons:
-      - dns
-      - rbac
-      - hostpath-storage
-      - metallb:10.64.140.43-10.64.140.49
     
 host:
   snaps:

--- a/spread.yaml
+++ b/spread.yaml
@@ -97,10 +97,11 @@ suites:
 path: /root/spread_project
 
 kill-timeout: 1h
+warn-timeout: 1m
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
-  MICROK8S_CHANNEL: "1.28-strict/stable"
+  MICROK8S_CHANNEL: "1.32-strict/stable"
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/spread.yaml
+++ b/spread.yaml
@@ -100,6 +100,7 @@ kill-timeout: 1h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL/juju36: 3.6/stable
+  MICROK8S_CHANNEL: "1.28-strict/stable"
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -119,6 +120,28 @@ prepare-each: |
 
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
   concierge prepare --trace
+
+  if [[ -v USES_K8S ]]; then
+      # calico has issues with strict confinements, so remove -strict
+      sudo snap install microk8s --channel "${MICROK8S_CHANNEL//'-strict'/}" --classic
+
+      sudo usermod -a -G microk8s "$USER"
+      mkdir -p ~/.kube
+      chmod 0700 ~/.kube
+
+      # make juju work with microk8s --classic
+      sudo mkdir -p /var/snap/juju/current/microk8s/credentials
+      sudo microk8s config | sudo tee /var/snap/juju/current/microk8s/credentials/client.config
+      sudo chown -R "$USER":"$USER" /var/snap/juju/current/microk8s/credentials
+
+      IP_ADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+      sudo microk8s enable dns
+      sudo microk8s enable hostpath-storage
+      sudo microk8s enable metallb:"$IP_ADDR"-"$IP_ADDR"
+
+      juju bootstrap microk8s
+      juju switch concierge-lxd
+  fi
 
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050

--- a/tests/integration/application-charm/charmcraft.yaml
+++ b/tests/integration/application-charm/charmcraft.yaml
@@ -10,7 +10,6 @@ charm-libs:
     version: "2"
   - lib: data_platform_libs.data_interfaces
     version: "1"
-    
 
 # Files implicitly created by charmcraft without a part:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
@@ -57,7 +56,7 @@ parts:
     after:
       - poetry-deps
     poetry-export-extra-args: ['--only', 'main,charm-libs']
-    poetry-pip-extra-args: ["--only-binary=cassandra-driver"]    
+    poetry-pip-extra-args: ["--only-binary=cassandra-driver"]
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source
@@ -74,7 +73,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.93.1  # renovate: charmcraft-rust-latest
 
 
       craftctl default

--- a/tests/spread/test_cos.py/task.yaml
+++ b/tests/spread/test_cos.py/task.yaml
@@ -1,4 +1,6 @@
 summary: test_cos.py
+environment:
+  USES_K8S: "true"
 execute: |
   tox run -e integration-cos -- --alluredir="$SPREAD_TASK/allure-results" --model-name=test-cas --keep-models
 artifacts:


### PR DESCRIPTION
## Description

- Bumps rust version to latest stable in builds
- Due to `microk8s` strict mode incompatibility with newer kernel version, switches to non-strict mode for COS tests.
- Some enhancement in `spread` configuration to avoid unnecessary bootstrap of a k8s controller where not needed.